### PR TITLE
added proper debugging functionality: defined bug(), so D(bug(...)); …

### DIFF
--- a/HOW_TO_BUILD_AMIGAOS4.txt
+++ b/HOW_TO_BUILD_AMIGAOS4.txt
@@ -142,8 +142,8 @@ cmake .. \
     -DENABLE_YARR:BOOL=ON
 
 
-Then while we in that "build" directory, we just do "make -f Makefile Odyssey -j4" (-j4 is to use 4 cores to speed the
-compilation process).
+Then while we in that "build" directory, we just do "make Odyssey -j4" (-j4 is to use 4 cores to speed the compilation
+process).
 
 If all will go fine, you will end up with the "Odyssey" binary placed in the build/bin directory. Take a release archive
 from os4depot, and replace the binary with a new one to do tests.

--- a/SDK.txt
+++ b/SDK.txt
@@ -33,4 +33,3 @@ ffmpeg      - v2.2.16 Frank's amiga shared libraries implementation: https://sou
 webp        - v1.1.0
 bz2         - v1.0.5
 aos4deps    - sttcpy() and DoSuperNew() realisations.
-debug       - just for kprintf

--- a/odyssey-r155188-1.23/BAL/Accessibility/WebCore/Generic/BCAccessibilityObjectWrapperGeneric.h
+++ b/odyssey-r155188-1.23/BAL/Accessibility/WebCore/Generic/BCAccessibilityObjectWrapperGeneric.h
@@ -27,7 +27,12 @@
 #ifndef AccessibilityObjectWrapper_h
 #define AccessibilityObjectWrapper_h
 
-#include <clib/debug_protos.h>
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 namespace WebCore {
 
@@ -46,7 +51,7 @@ namespace WebCore {
         {
             // FIXME: Remove this once our immediate subclass no longer uses COM.
             
-	    kprintf("Disabled addressOfCount()=0 in AccessibilityObjectWrapper... is it even used?");
+	    D(bug("Disabled addressOfCount()=0 in AccessibilityObjectWrapper... is it even used?"));
 	    //*addressOfCount() = 0;
         }
         AccessibilityObjectWrapper() : m_object(0) { }

--- a/odyssey-r155188-1.23/BAL/Events/WebCore/MorphOS/BCPlatformKeyboardEventMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Events/WebCore/MorphOS/BCPlatformKeyboardEventMorphOS.cpp
@@ -38,7 +38,6 @@
 #include "CString.h"
 #include <wtf/text/WTFString.h>
 
-#include <clib/debug_protos.h>
 #include <proto/keymap.h>
 #include <proto/diskfont.h>
 #include <diskfont/diskfonttag.h>
@@ -48,7 +47,13 @@
 #include "../../../../WebKit/OrigynWebBrowser/Api/MorphOS/gui.h"
 #undef String
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
+
 
 extern uint32 amigaToUnicodeChar(uint32 c);
 
@@ -515,13 +520,13 @@ PlatformKeyboardEvent::PlatformKeyboardEvent(BalEventKey* event)
 	prev_CtrlKey  = ctrlKey();
 	prev_MetaKey  = metaKey();
 
-	D(kprintf("Qualifier Shift %d Alt %d Ctrl %d Meta %d\n", m_shiftKey, m_altKey, m_ctrlKey, m_metaKey));
-	D(kprintf("RawKey %x Qualifier %x\n", m_balEventKey->Code, m_balEventKey->Qualifier));
-	D(kprintf("Text <%s>\n", m_text.latin1().data()));
-	D(kprintf("Unmodified Text <%s>\n", m_unmodifiedText.latin1().data()));
-	D(kprintf("VirtualKey %x\n", m_windowsVirtualKeyCode));
-	D(kprintf("KeyIdentifier <%s>\n", m_keyIdentifier.latin1().data()));
-	D(kprintf("\n\n\n"));
+	//D(bug("Qualifier Shift %d Alt %d Ctrl %d Meta %d\n", m_shiftKey, m_altKey, m_ctrlKey, m_metaKey));
+	D(bug("RawKey %x Qualifier %x\n", m_balEventKey->Code, m_balEventKey->Qualifier));
+	D(bug("Text <%s>\n", m_text.latin1().data()));
+	D(bug("Unmodified Text <%s>\n", m_unmodifiedText.latin1().data()));
+	D(bug("VirtualKey %x\n", m_windowsVirtualKeyCode));
+	D(bug("KeyIdentifier <%s>\n", m_keyIdentifier.latin1().data()));
+	D(bug("\n\n\n"));
 
 }
 
@@ -544,7 +549,7 @@ void PlatformKeyboardEvent::disambiguateKeyDownEvent(Type type, bool backwardCom
 		if (m_text.isEmpty() && m_windowsVirtualKeyCode && m_balEventKey->Code < RAWKEY_ESCAPE)
             m_text.append(UChar(m_windowsVirtualKeyCode));
 
-		D(kprintf("DisambiguateKeyDownEvent <%s>\n", m_text.latin1().data()));
+		D(bug("DisambiguateKeyDownEvent <%s>\n", m_text.latin1().data()));
         m_keyIdentifier = String();
         m_windowsVirtualKeyCode = 0;
     }
@@ -552,7 +557,7 @@ void PlatformKeyboardEvent::disambiguateKeyDownEvent(Type type, bool backwardCom
 
 bool PlatformKeyboardEvent::currentCapsLockState()
 {
-	D(kprintf("currentCapsLockState\n"));
+	D(bug("currentCapsLockState\n"));
     return false;
 }
 
@@ -568,7 +573,7 @@ void PlatformKeyboardEvent::getCurrentModifierState(bool& shiftKey, bool& ctrlKe
 	altKey   = prev_AltKey;
 	metaKey  = prev_MetaKey;
 
-	D(kprintf("getCurrentModifierState Shift %d Alt %d Ctrl %d Meta %d\n", shiftKey, altKey, ctrlKey, metaKey));
+	D(bug("getCurrentModifierState Shift %d Alt %d Ctrl %d Meta %d\n", shiftKey, altKey, ctrlKey, metaKey));
 }
 
 }

--- a/odyssey-r155188-1.23/BAL/Events/WebCore/MorphOS/BCPlatformMouseEventMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Events/WebCore/MorphOS/BCPlatformMouseEventMorphOS.cpp
@@ -35,7 +35,6 @@
 #include <math.h>
 #include <intuition/intuition.h>
 #include <proto/intuition.h>
-#include <clib/debug_protos.h>
 
 namespace WebCore {
 

--- a/odyssey-r155188-1.23/BAL/Events/WebCore/MorphOS/BCPlatformWheelEventMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Events/WebCore/MorphOS/BCPlatformWheelEventMorphOS.cpp
@@ -36,7 +36,14 @@
 #include <intuition/intuition.h>
 #include <devices/rawkeycodes.h>
 #include <devices/inputevent.h>
-#include <clib/debug_protos.h>
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
 
 namespace WebCore {
 
@@ -97,7 +104,7 @@ PlatformWheelEvent::PlatformWheelEvent(BalEventScroll* event)
 	}
 	else if (shiftKey())
 	{
-		// kprintf("window (%d, %d)\n", event->IDCMPWindow->Width, event->IDCMPWindow->Height);
+		// D(bug("window (%d, %d)\n", event->IDCMPWindow->Width, event->IDCMPWindow->Height));
         m_granularity = ScrollByPageWheelEvent;
 		deltax = (int)deltax * event->IDCMPWindow->Width / 50;
 		deltay = (int)deltay * event->IDCMPWindow->Height / 50;

--- a/odyssey-r155188-1.23/BAL/Facilities/WebCore/Linux/BCFileIOLinux.cpp
+++ b/odyssey-r155188-1.23/BAL/Facilities/WebCore/Linux/BCFileIOLinux.cpp
@@ -39,9 +39,14 @@
 #include <dos/dos.h>
 #include <proto/dos.h>
 #include <proto/asyncio.h>
-#include <clib/debug_protos.h>
-#define D(x)
 #endif
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 #ifdef __amigaos4__
 
@@ -59,14 +64,14 @@ OWBFile::OWBFile(const String path)
 	: m_fd(0)
     , m_filePath(path)
 {
-	D(kprintf("[File] File(%s) (0x%p)\n", m_filePath.latin1().data(), m_fd));
+	D(bug("[File] File(%s) (0x%p)\n", m_filePath.latin1().data(), m_fd));
 }
 
 OWBFile::~OWBFile()
 {
-	D(kprintf("[File] ~File(%s) (0x%p)\n", m_filePath.latin1().data(), m_fd));
+	D(bug("[File] ~File(%s) (0x%p)\n", m_filePath.latin1().data(), m_fd));
 	close();
-	D(kprintf("[File] ~File() OK\n"));
+	D(bug("[File] ~File() OK\n"));
 }
 
 int OWBFile::open(char openType)
@@ -87,7 +92,7 @@ int OWBFile::open(char openType)
 	
 	stccpy(name, m_filePath.latin1().data(), sizeof(name));
 
-	D(kprintf("[File] open(%s, '%c')\n", name, openType));
+	D(bug("[File] open(%s, '%c')\n", name, openType));
 
 	// Check that m_fd is 0, if that's not the case it means that an open file
     // has not been closed, so close it before continuing.
@@ -124,7 +129,7 @@ int OWBFile::open(char openType)
 	if(fd)
 	{
 		m_fd = (void *) fd;
-		D(kprintf("[File] Opened <%s> successfully (0x%p)\n", m_filePath.latin1().data(), m_fd));
+		D(bug("[File] Opened <%s> successfully (0x%p)\n", m_filePath.latin1().data(), m_fd));
 	}
 	else
 	{
@@ -142,14 +147,14 @@ void OWBFile::close()
 	{ /*
 		if((int) m_fd < 0x1000)
 		{
-			kprintf("[File] m_fd 0x%p is highly suspicious, skipping\n", m_fd);
-			kprintf("[File] Dumping task state\n");
+			D(bug("[File] m_fd 0x%p is highly suspicious, skipping\n", m_fd));
+			D(bug("[File] Dumping task state\n"));
 			DumpTaskState(FindTask(NULL));
 			m_fd = 0;
 			return;
 		}
 	 */
-		D(kprintf("[File] close(%s) (0x%p)\n", m_filePath.latin1().data(), m_fd));
+		D(bug("[File] close(%s) (0x%p)\n", m_filePath.latin1().data(), m_fd));
 		CloseAsync((struct AsyncFile *) m_fd);
 		m_fd = 0;
     }

--- a/odyssey-r155188-1.23/BAL/Facilities/WebCore/MorphOS/BCLoggingMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Facilities/WebCore/MorphOS/BCLoggingMorphOS.cpp
@@ -42,7 +42,6 @@
 #include <dos/dosextens.h>
 #include <proto/dos.h>
 #include <proto/exec.h>
-#include <clib/debug_protos.h>
 #include <string.h>
 
 #undef String

--- a/odyssey-r155188-1.23/BAL/Filesystem/WebCore/Posix/BCFileSystemPosix.cpp
+++ b/odyssey-r155188-1.23/BAL/Filesystem/WebCore/Posix/BCFileSystemPosix.cpp
@@ -36,7 +36,6 @@
 #include <exec/exec.h>
 #include <proto/exec.h>
 #include <proto/wb.h>
-#include <clib/debug_protos.h>
 #else
 #include <libgen.h>
 #endif
@@ -47,6 +46,14 @@
 //#include <regex.h>
 #include <dirent.h>
 #include <string>
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
 using namespace std;
 
 #include <wtf/text/CString.h>
@@ -471,7 +478,7 @@ String openTemporaryFile(const String& prefix, PlatformFileHandle &handle)
 
 	if (!isHandleValid(fileDescriptor))
 	 {
-		kprintf("Can't create temporary file <%s>\n", tempPath);
+		D(bug("Can't create temporary file <%s>\n", tempPath));
                 return String();
          }
     String tempFilePath = tempPath;

--- a/odyssey-r155188-1.23/BAL/Fonts/WebCore/Cairo/BCFontCairo.cpp
+++ b/odyssey-r155188-1.23/BAL/Fonts/WebCore/Cairo/BCFontCairo.cpp
@@ -42,6 +42,14 @@
 #include "ShadowBlur.h"
 #include "SimpleFontData.h"
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
+
 namespace WebCore {
 
 static void drawGlyphsToContext(cairo_t* context, const SimpleFontData* font, GlyphBufferGlyph* glyphs, int numGlyphs)
@@ -95,8 +103,6 @@ static void drawGlyphsShadow(GraphicsContext* graphicsContext, const FloatPoint&
 }
 
 #if OS(MORPHOS)
-#include <clib/debug_protos.h>
-
 bool Font::canReturnFallbackFontsForComplexText()
 {
     return false;
@@ -116,7 +122,7 @@ void Font::drawComplexText(GraphicsContext* context, const TextRun& run, const F
 void Font::drawEmphasisMarksForComplexText(GraphicsContext* /* context */, const TextRun& /* run */, const AtomicString& /* mark */, const FloatPoint& /* point */, int /* fm */, int /* to */) const
 {
 #warning "not implemented"
-    kprintf("Font::drawEmphasisMarksForComplexText not implemented\n");
+    D(bug("Font::drawEmphasisMarksForComplexText not implemented\n"));
 }
 
 float Font::floatWidthForComplexText(const TextRun& run, HashSet<const SimpleFontData*>* fallbackFonts, GlyphOverflow* glyphOverflow) const

--- a/odyssey-r155188-1.23/BAL/Graphics/WebCore/Cairo/BCGraphicsContextCairo.cpp
+++ b/odyssey-r155188-1.23/BAL/Graphics/WebCore/Cairo/BCGraphicsContextCairo.cpp
@@ -64,8 +64,6 @@
 #include <cairo-win32.h>
 #endif
 
-#include <clib/debug_protos.h>
-
 using namespace std;
 
 namespace WebCore {

--- a/odyssey-r155188-1.23/BAL/Graphics/WebCore/MorphOS/BCDragImageMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Graphics/WebCore/MorphOS/BCDragImageMorphOS.cpp
@@ -28,8 +28,12 @@
 #include "RefPtrCairo.h"
 #include "../../../../Source/WebKit/OrigynWebBrowser/Api/MorphOS/gui.h"
 #include <cairo.h>
-#include <clib/debug_protos.h>
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 namespace WebCore {
@@ -93,7 +97,7 @@ DragImageRef createDragImageIconForCachedImageFilename(const String&)
 
 DragImageRef createDragImageForLink(KURL& url, const String& inLabel, FontRenderingMode fontRenderingMode, Frame* frame)
 {
-    D(kprintf("createDragImageForLink %s %s\n", url.string().latin1().data(), inLabel.latin1().data()));
+    D(bug("createDragImageForLink %s %s\n", url.string().latin1().data(), inLabel.latin1().data()));
 
     FrameView *frameView = frame->view();
     BalWidget *widget = frameView->hostWindow()->platformPageClient();

--- a/odyssey-r155188-1.23/BAL/Graphics/WebCore/MorphOS/BCImageMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Graphics/WebCore/MorphOS/BCImageMorphOS.cpp
@@ -29,7 +29,6 @@
 #include "SharedBuffer.h"
 #include "WTFString.h"
 #include "CString.h"
-#include <clib/debug_protos.h>
 
 namespace WebCore {
 

--- a/odyssey-r155188-1.23/BAL/Media/WebCore/MorphOS/acinerella.c
+++ b/odyssey-r155188-1.23/BAL/Media/WebCore/MorphOS/acinerella.c
@@ -36,12 +36,15 @@
 
 #include <string.h>
 #include <proto/exec.h>
-#include <clib/debug_protos.h>
-
 
 #include "../../../../WebKit/OrigynWebBrowser/Api/MorphOS/gui.h"
 #include "acinerella.h"
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 #define AUDIO_BUFFER_BASE_SIZE ((192000 * 3) / 2)
@@ -234,7 +237,7 @@ static void av_log_callback(void* ptr, int level, const char* fmt, va_list vl)
 	/*
 	char buffer[512];
 	vsnprintf(buffer, sizeof(buffer), fmt, vl);
-	kprintf(buffer);
+	D(bug(buffer));
 	*/
 }
 
@@ -273,7 +276,7 @@ lp_ac_instance CALL_CONVT ac_init(void)
 	{
 		InitSemaphore(&semAcinerella);
 		
-		D(kprintf("Initializing ffmpeg\n"));
+		D(bug("Initializing ffmpeg\n"));
 
 		ObtainSemaphore(&semAcinerella);
 		
@@ -335,7 +338,7 @@ int CALL_CONVT ac_open(
 
 	//Generate a unique filename
 	snprintf(filename, sizeof(filename), "%s://%p", "owb", pacInstance);
-	D(kprintf("filename: <%s> instance <%p>\n", filename, pacInstance));
+	D(bug("filename: <%s> instance <%p>\n", filename, pacInstance));
 
 	((lp_ac_data)pacInstance)->pFormatCtx =	avformat_alloc_context();
 	if(avformat_open_input(&(((lp_ac_data)pacInstance)->pFormatCtx), filename, NULL, NULL) != 0)
@@ -534,7 +537,7 @@ lp_ac_package CALL_CONVT ac_read_package(lp_ac_instance pacInstance)
 				{
 					pTmp->pts = clone->dts;
 				}
-				D(kprintf("Allocate packet %p (data %p size %d stream %d destruct %p priv %p)\n", pTmp, pTmp->package.data, pTmp->package.size, pTmp->package.stream_index, pTmp->ffpackage->destruct, pTmp->ffpackage->priv));
+				D(bug("Allocate packet %p (data %p size %d stream %d destruct %p priv %p)\n", pTmp, pTmp->package.data, pTmp->package.size, pTmp->package.stream_index, pTmp->ffpackage->destruct, pTmp->ffpackage->priv));
 			}
 			return (lp_ac_package)(pTmp);
 		}
@@ -549,7 +552,7 @@ void CALL_CONVT ac_free_package(lp_ac_package pPackage)
 	//Free the packet
 	if (pPackage != NULL && pPackage != ac_flush_packet())
 	{
-		D(kprintf("Free packet %p (data %p size %d stream %d destruct %p priv %p)\n", pPackage, ((lp_ac_package_data)pPackage)->package.data, ((lp_ac_package_data)pPackage)->package.size, ((lp_ac_package_data)pPackage)->package.stream_index, ((lp_ac_package_data)pPackage)->ffpackage->destruct, ((lp_ac_package_data)pPackage)->ffpackage->priv));
+		D(bug("Free packet %p (data %p size %d stream %d destruct %p priv %p)\n", pPackage, ((lp_ac_package_data)pPackage)->package.data, ((lp_ac_package_data)pPackage)->package.size, ((lp_ac_package_data)pPackage)->package.stream_index, ((lp_ac_package_data)pPackage)->ffpackage->destruct, ((lp_ac_package_data)pPackage)->ffpackage->priv));
 		av_free_packet(((lp_ac_package_data)pPackage)->ffpackage);
 		mgr_free(((lp_ac_package_data)pPackage)->ffpackage);
 		mgr_free((lp_ac_package_data)pPackage);
@@ -616,7 +619,7 @@ int	ac_set_output_format(lp_ac_decoder decoder, ac_output_format fmt)
 		    //Reserve buffer memory
 		    if(!pDecoder->pCodecCtx->width || !pDecoder->pCodecCtx->height)
 		    {
-				D(kprintf("Invalid video size\n"));
+				D(bug("Invalid video size\n"));
 				ReleaseSemaphore(&pDecoder->sem);
 				return -1;
 		    }
@@ -739,7 +742,7 @@ void* ac_create_video_decoder(lp_ac_instance pacInstance, lp_ac_stream_info info
 	  
 	if(!pDecoder->pCodecCtx->width || !pDecoder->pCodecCtx->height)
 	{
-		D(kprintf("Invalid video size\n"));
+		D(bug("Invalid video size\n"));
 		ac_free_decoder((lp_ac_decoder)pDecoder);
 		return NULL;
 	}
@@ -986,7 +989,7 @@ int CALL_CONVT ac_decode_package(lp_ac_package pPackage, lp_ac_decoder pDecoder)
 	    }
 	}
 	  
-	D(kprintf("Decode packet %p (data %p size %d stream %d destruct %p priv %p)\n", pPackage, ((lp_ac_package_data)pPackage)->package.data, ((lp_ac_package_data)pPackage)->package.size, ((lp_ac_package_data)pPackage)->package.stream_index, ((lp_ac_package_data)pPackage)->ffpackage->destruct, ((lp_ac_package_data)pPackage)->ffpackage->priv));
+	D(bug("Decode packet %p (data %p size %d stream %d destruct %p priv %p)\n", pPackage, ((lp_ac_package_data)pPackage)->package.data, ((lp_ac_package_data)pPackage)->package.size, ((lp_ac_package_data)pPackage)->package.stream_index, ((lp_ac_package_data)pPackage)->ffpackage->destruct, ((lp_ac_package_data)pPackage)->ffpackage->priv));
 
 	if(pDecoder->type == AC_DECODER_TYPE_VIDEO)
 	{

--- a/odyssey-r155188-1.23/BAL/Memory/WTF/BCFastMallocWTF.cpp
+++ b/odyssey-r155188-1.23/BAL/Memory/WTF/BCFastMallocWTF.cpp
@@ -119,6 +119,13 @@
 #define USE_BACKGROUND_THREAD_TO_SCAVENGE_MEMORY 1
 #endif
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
 #ifndef NDEBUG
 namespace WTF {
 
@@ -240,7 +247,6 @@ TryMallocReturnValue tryFastZeroedMalloc(size_t n)
 #if OS(WINDOWS)
 #include <malloc.h>
 #elif OS(MORPHOS)
-#include <clib/debug_protos.h>
 extern int morphos_crash(size_t);
 #endif
 
@@ -293,7 +299,7 @@ TryMallocReturnValue tryFastMalloc(size_t n)
     fastMallocValidate(result);
 #if OS(MORPHOS)
     g_memory_allocated += n + Internal::ValidationBufferSize;
-    //kprintf("+ g_memory_allocated %d (+%d)\n", g_memory_allocated, n);
+    //D(bug("+ g_memory_allocated %d (+%d)\n", g_memory_allocated, n));
 
     if (g_limit != 0 && (g_memory_allocated > g_limit)) {
 	if (g_memoryNotification)
@@ -321,7 +327,7 @@ retry:
     
     if (!result) 
     {
-	kprintf("fastMalloc: Failed to allocate %lu bytes. Happy crash sponsored by WebKit will follow.\n", n ? n : 2); 
+	D(bug("fastMalloc: Failed to allocate %lu bytes. Happy crash sponsored by WebKit will follow.\n", n ? n : 2)); 
 	if(morphos_crash(n ? n : 2)) 
 	    goto retry;
     }
@@ -365,7 +371,7 @@ retry:
     void* result = calloc(n_elements ? n_elements : 1, element_size ? element_size : 2);
     if (!result) 
     {
-	kprintf("fastCalloc: Failed to allocate %lu x %lu bytes. Happy crash sponsored by WebKit will follow.\n", n_elements ? n_elements : 1, element_size ? element_size : 2);
+	D(bug("fastCalloc: Failed to allocate %lu x %lu bytes. Happy crash sponsored by WebKit will follow.\n", n_elements ? n_elements : 1, element_size ? element_size : 2));
 	if(morphos_crash((n_elements ? n_elements : 1)*(element_size ? element_size : 2))) 
 	    goto retry;
     }
@@ -384,7 +390,7 @@ void fastFree(void* p)
 
 #if OS(MORPHOS)
     g_memory_allocated -= (fastMallocSize(p) + Internal::ValidationBufferSize);
-    //kprintf("- g_memory_allocated %d (-%d)\n", g_memory_allocated, fastMallocSize(p));
+    //D(bug("- g_memory_allocated %d (-%d)\n", g_memory_allocated, fastMallocSize(p)));
 #endif    
     fastMallocMatchValidateFree(p, Internal::AllocTypeMalloc);
     Internal::ValidationHeader* header = Internal::fastMallocValidationHeader(p);
@@ -406,14 +412,14 @@ TryMallocReturnValue tryFastRealloc(void* p, size_t n)
         fastMallocValidate(p);
 #if OS(MORPHOS)
 	g_memory_allocated -= (fastMallocSize(p) + Internal::ValidationBufferSize);
-	//kprintf("- g_memory_allocated %d (-%d)\n", g_memory_allocated, fastMallocSize(p));
+	//D(bug("- g_memory_allocated %d (-%d)\n", g_memory_allocated, fastMallocSize(p)));
 #endif
         Internal::ValidationHeader* result = static_cast<Internal::ValidationHeader*>(realloc(Internal::fastMallocValidationHeader(p), n + Internal::ValidationBufferSize));
         if (!result)
             return 0;
 #if OS(MORPHOS)
         g_memory_allocated += n + Internal::ValidationBufferSize;
-	//kprintf("+ g_memory_allocated %d (+%d)\n", g_memory_allocated, n);
+	//D(bug("+ g_memory_allocated %d (+%d)\n", g_memory_allocated, n));
 
 	if (g_limit != 0 && (g_memory_allocated > g_limit)) {
 	    if (g_memoryNotification)
@@ -448,7 +454,7 @@ retry:
 
     if (!result)
     {
-	kprintf("fastRealloc: Failed to allocate %lu bytes. Happy crash sponsored by WebKit will follow.\n", n ? n : 2);
+	D(bug("fastRealloc: Failed to allocate %lu bytes. Happy crash sponsored by WebKit will follow.\n", n ? n : 2));
 	if(morphos_crash(n ? n : 2))
 	    goto retry;
     }

--- a/odyssey-r155188-1.23/BAL/Memory/WTF/BCOSAllocatorMorphOSWTF.cpp
+++ b/odyssey-r155188-1.23/BAL/Memory/WTF/BCOSAllocatorMorphOSWTF.cpp
@@ -29,7 +29,12 @@
 #include <wtf/FastMalloc.h>
 
 #include <string.h>
-#include <clib/debug_protos.h>
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 namespace WTF {
@@ -37,30 +42,30 @@ namespace WTF {
 void* OSAllocator::reserveUncommitted(size_t bytes, Usage usage, bool, bool, bool)
 {
     void *ptr = fastMalloc(bytes);
-    D(kprintf("A %p | OSAllocator::reserveUncommitted(%lu usage %d)\n", ptr, bytes, usage));
+    D(bug("A %p | OSAllocator::reserveUncommitted(%lu usage %d)\n", ptr, bytes, usage));
     return ptr;
 }
 
 void* OSAllocator::reserveAndCommit(size_t bytes, Usage usage, bool, bool, bool)
 {
     void *ptr = fastMalloc(bytes);
-    D(kprintf("A %p | OSAllocator::reserveAndCommit(%lu usage %d)\n", ptr, bytes, usage));
+    D(bug("A %p | OSAllocator::reserveAndCommit(%lu usage %d)\n", ptr, bytes, usage));
     return ptr;
 }
 
 void OSAllocator::commit(void* address, size_t bytes, bool, bool)
 {
-    //D(kprintf("OSAllocator::commit(%p, %lu)\n", address, bytes));
+    //D(bug("OSAllocator::commit(%p, %lu)\n", address, bytes));
 }
 
 void OSAllocator::decommit(void* address, size_t bytes)
 {
-    //D(kprintf("OSAllocator::decommit(%p, %lu)\n", address, bytes));
+    //D(bug("OSAllocator::decommit(%p, %lu)\n", address, bytes));
 }
 
 void OSAllocator::releaseDecommitted(void* address, size_t bytes)
 {
-    D(kprintf("D %p | OSAllocator::releaseDecommitted(%p, %lu)\n", address, address, bytes));
+    D(bug("D %p | OSAllocator::releaseDecommitted(%p, %lu)\n", address, address, bytes));
     fastFree(address);
 }
 

--- a/odyssey-r155188-1.23/BAL/Network/WebCore/Curl/BCCookieDatabaseBackingStoreCurl.cpp
+++ b/odyssey-r155188-1.23/BAL/Network/WebCore/Curl/BCCookieDatabaseBackingStoreCurl.cpp
@@ -38,13 +38,19 @@
 
 #include "../../../Source/WebKit/OrigynWebBrowser/Api/MorphOS/gui.h"
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
 #if ENABLE_COOKIE_DEBUG
-#include <clib/debug_protos.h>
 #include <stdio.h>
 //#define CookieLog(format, ...) do { char buffer[1024]; snprintf(buffer, sizeof(buffer), __VA_ARGS__); DoMethod(app, MM_OWBApp_AddConsoleMessage, buffer); } while (0)
-#define CookieLog kprintf
+#define CookieLog bug
 #undef LOG_ERROR
-#define LOG_ERROR kprintf
+#define LOG_ERROR bug
 #else
 #define CookieLog(format, ...)
 #endif

--- a/odyssey-r155188-1.23/BAL/Network/WebCore/Curl/BCCookieManagerCurl.cpp
+++ b/odyssey-r155188-1.23/BAL/Network/WebCore/Curl/BCCookieManagerCurl.cpp
@@ -42,23 +42,29 @@
 #include <wtf/text/WTFString.h>
 
 #include "../../../WebKit/OrigynWebBrowser/Api/MorphOS/gui.h"
-#include <clib/debug_protos.h>
 #include <stdio.h>
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 #if ENABLE_COOKIE_SUPER_VERBOSE_DEBUG
 //#define CookieLog(format, ...) do { char buffer[1024]; snprintf(buffer, sizeof(buffer), __VA_ARGS__); DoMethod(app, MM_OWBApp_AddConsoleMessage, buffer); } while (0)
-#define CookieLog kprintf
+#define CookieLog bug
 #undef LOG_ERROR
-#define LOG_ERROR kprintf
+#define LOG_ERROR bug
 #else
 #define CookieLog(format, ...)
 #endif // ENABLE_COOKIE_SUPER_VERBOSE_DEBUG
 
 #if ENABLE_COOKIE_LIMIT_DEBUG
 //#define CookieLimitLog(format, ...) do { char buffer[1024]; snprintf(buffer, sizeof(buffer), __VA_ARGS__); DoMethod(app, MM_OWBApp_AddConsoleMessage, buffer); } while (0)
-#define CookieLimitLog kprintf
+#define CookieLimitLog bug
 #undef LOG_ERROR
-#define LOG_ERROR kprintf
+#define LOG_ERROR bug
 #else
 #define CookieLimitLog(format, ...)
 #endif // ENABLE_COOKIE_LIMIT_DEBUG

--- a/odyssey-r155188-1.23/BAL/Network/WebCore/Curl/BCCookieParserCurl.cpp
+++ b/odyssey-r155188-1.23/BAL/Network/WebCore/Curl/BCCookieParserCurl.cpp
@@ -33,7 +33,6 @@
 #include <wtf/CurrentTime.h>
 #include <wtf/text/CString.h>
 #include "../../../WebKit/OrigynWebBrowser/Api/MorphOS/gui.h"
-#include <clib/debug_protos.h>
 #include <stdio.h>
 
 namespace WebCore {

--- a/odyssey-r155188-1.23/BAL/Network/WebCore/Curl/BCResourceHandleCurl.cpp
+++ b/odyssey-r155188-1.23/BAL/Network/WebCore/Curl/BCResourceHandleCurl.cpp
@@ -46,12 +46,17 @@
 
 #if OS(MORPHOS)
 #include "../../../../WebKit/OrigynWebBrowser/Api/MorphOS/gui.h"
-#include <clib/debug_protos.h>
-#define D(x)
 #undef String
 #undef set
 #undef get
 #endif
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 namespace WebCore {
 
@@ -336,7 +341,7 @@ void ResourceHandle::receivedCredential(const AuthenticationChallenge& challenge
 #if OS(MORPHOS)
 	    String host = challenge.protectionSpace().host();
 	    String realm = challenge.protectionSpace().realm();
-	    //kprintf("Storing credentials in db for host %s realm %s (%s %s)\n", host.utf8().data(), realm.utf8().data(), credential.user().utf8().data(), credential.password().utf8().data());
+	    //D(bug("Storing credentials in db for host %s realm %s (%s %s)\n", host.utf8().data(), realm.utf8().data(), credential.user().utf8().data(), credential.password().utf8().data()));
 	    methodstack_push_sync(app, 4, MM_OWBApp_SetCredential, &host, &realm, &credential);
 #endif
         }

--- a/odyssey-r155188-1.23/BAL/Network/WebCore/Curl/BCResourceHandleManagerCurl.cpp
+++ b/odyssey-r155188-1.23/BAL/Network/WebCore/Curl/BCResourceHandleManagerCurl.cpp
@@ -71,7 +71,6 @@
 #if OS(MORPHOS)
 #include <unistd.h>
 #include <sys/signal.h>
-#include <clib/debug_protos.h>
 #include <exec/memory.h>
 #include <exec/semaphores.h>
 #include <dos/dostags.h>

--- a/odyssey-r155188-1.23/BAL/Network/WebCore/WK/BCDataURLWK.cpp
+++ b/odyssey-r155188-1.23/BAL/Network/WebCore/WK/BCDataURLWK.cpp
@@ -35,9 +35,6 @@
 #include "TextEncoding.h"
 #include <wtf/text/Base64.h>
 #include <wtf/text/CString.h>
-#if OS(MORPHOS)
-#include <clib/debug_protos.h>
-#endif
 
 namespace WebCore {
 

--- a/odyssey-r155188-1.23/BAL/Types/WTF/BCDateMathWTF.cpp
+++ b/odyssey-r155188-1.23/BAL/Types/WTF/BCDateMathWTF.cpp
@@ -108,7 +108,6 @@
 #endif
 
 #if OS(MORPHOS)
-#include <clib/debug_protos.h>
 extern long get_DST_offset(void);
 extern long get_GMT_offset(void);
 #endif

--- a/odyssey-r155188-1.23/BAL/Types/WTF/BCGregorianDateTimeWTF.cpp
+++ b/odyssey-r155188-1.23/BAL/Types/WTF/BCGregorianDateTimeWTF.cpp
@@ -33,8 +33,6 @@
 #include <time.h>
 #endif
 
-#include <clib/debug_protos.h>
-
 namespace WTF {
 
 void GregorianDateTime::setToCurrentLocalTime()

--- a/odyssey-r155188-1.23/BAL/Types/WTF/BCThreadSpecificWTF.cpp
+++ b/odyssey-r155188-1.23/BAL/Types/WTF/BCThreadSpecificWTF.cpp
@@ -43,7 +43,6 @@
 #include "ThreadSpecific.h"
 
 #include <proto/exec.h>
-#include <clib/debug_protos.h>
 
 namespace WTF {
 

--- a/odyssey-r155188-1.23/BAL/Types/WTF/BCWTFThreadDataWTF.cpp
+++ b/odyssey-r155188-1.23/BAL/Types/WTF/BCWTFThreadDataWTF.cpp
@@ -29,8 +29,12 @@
 
 #include <wtf/text/AtomicStringTable.h>
 
-#define kprintf IExec->DebugPrintF
-#define D(x) x
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 #if USE(WEB_THREAD)
 #include <wtf/MainThread.h>

--- a/odyssey-r155188-1.23/BAL/Types/WTF/MorphOS/BCMainThreadMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Types/WTF/MorphOS/BCMainThreadMorphOS.cpp
@@ -29,8 +29,11 @@
 #include "config.h"
 #include "MainThread.h"
 
-#include <clib/debug_protos.h>
-
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 #if OS(MORPHOS)
@@ -44,12 +47,12 @@ namespace WTF {
 
 void initializeMainThreadPlatform()
 {
-	D(kprintf("initializeMainThreadPlatform()\n"));
+	D(bug("initializeMainThreadPlatform()\n"));
 }
 
 void scheduleDispatchFunctionsOnMainThread()
 {
-	D(kprintf("scheduleDispatchFunctionsOnMainThread()\n"));
+	D(bug("scheduleDispatchFunctionsOnMainThread()\n"));
 	WakeTimer();
 }
 

--- a/odyssey-r155188-1.23/BAL/Types/WTF/MorphOS/BCThreadingMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Types/WTF/MorphOS/BCThreadingMorphOS.cpp
@@ -55,14 +55,15 @@
 #include <dos/dosextens.h>
 #include <proto/dos.h>
 #include <proto/exec.h>
-#include <clib/debug_protos.h>
 
-#ifdef __amigaos4__
-#define kprintf DebugPrintF
-#endif
 
-#define D(x) //x
-#define D2(x) //x
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+#define D2(x)
 
 
 namespace WTF {
@@ -184,33 +185,33 @@ static void initializeStaticTimerBase()
 
 void initializeThreading()
 {
-	D(kprintf("initializeThreading()\n")); 
+	D(bug("initializeThreading()\n")); 
 	if (!atomicallyInitializedStaticMutex)
 	{
-		D(kprintf("we in initializeThreading(): inside of the !atomicallyinitializedstaticmutex and before StringImp::empty\n"));
+		D(bug("we in initializeThreading(): inside of the !atomicallyinitializedstaticmutex and before StringImp::empty\n"));
 		StringImpl::empty();
-		D(kprintf("we in initializeThreading(): before atoicallyinitializedstaticmutex = new Mutex\n"));
+		D(bug("we in initializeThreading(): before atoicallyinitializedstaticmutex = new Mutex\n"));
 		atomicallyInitializedStaticMutex = new Mutex;
-		D(kprintf("we in initializeThreading(): before threadmapmutex()\n"));
+		D(bug("we in initializeThreading(): before threadmapmutex()\n"));
 		threadMapMutex();
-		D(kprintf("we in initializeThreading(): before syncportmapmutex()\n"));
+		D(bug("we in initializeThreading(): before syncportmapmutex()\n"));
 		syncPortMapMutex();
-		D(kprintf("we in initializeThreading(): before threadReplyStateMapMutex()\n"));
+		D(bug("we in initializeThreading(): before threadReplyStateMapMutex()\n"));
 		threadReplyStateMapMutex();
 
-		D(kprintf("we in initializeThreading(): before wtfThreadData()\n"));
+		D(bug("we in initializeThreading(): before wtfThreadData()\n"));
 		wtfThreadData();
-		D(kprintf("we in initializeThreading(): before initializeRandomNumberGenerator()\n"));
+		D(bug("we in initializeThreading(): before initializeRandomNumberGenerator()\n"));
 		initializeRandomNumberGenerator();
-		D(kprintf("we in initializeThreading(): before s_dtoap5mutex = new mutex\n"));
+		D(bug("we in initializeThreading(): before s_dtoap5mutex = new mutex\n"));
 		s_dtoaP5Mutex = new Mutex;
-		D(kprintf("we in initializeThreading(): before initializeDates\n"));
+		D(bug("we in initializeThreading(): before initializeDates\n"));
 		initializeDates();
 
-		D(kprintf("we in initializeThreading(): before mainthreadidentifier = currentThread()\n"));
+		D(bug("we in initializeThreading(): before mainthreadidentifier = currentThread()\n"));
 		mainThreadIdentifier = currentThread();
 		
-		D(kprintf("mainThreadIdentifier %d\n", mainThreadIdentifier));
+		D(bug("mainThreadIdentifier %d\n", mainThreadIdentifier));
 
 		initializeStaticTimerBase();
 	}
@@ -287,7 +288,7 @@ static ThreadIdentifier establishIdentifierForThreadHandle(APTR threadHandle)
 
 	static ThreadIdentifier identifierCount = 1;
 
-	D(kprintf("establishIdentifierForThreadHandle() adding thread id %lu\n", identifierCount));
+	D(bug("establishIdentifierForThreadHandle() adding thread id %lu\n", identifierCount));
 
 	threadMap().add(identifierCount, threadHandle);
 
@@ -316,7 +317,7 @@ static struct MsgPort* syncPortByProcess(APTR process)
 {
 	MutexLocker locker(syncPortMapMutex());
 
-	D(kprintf("syncPortByProcess(%p)\n", process));
+	D(bug("syncPortByProcess(%p)\n", process));
 
 	SyncPortMap::iterator i = syncPortMap().begin();
 	for (; i != syncPortMap().end(); ++i)
@@ -334,7 +335,7 @@ static struct MsgPort* createSyncPortForProcess(APTR process)
 
 	struct MsgPort *msgPort = CreateMsgPort();
 
-	D(kprintf("createSyncPortForThreadProcess(%p) -> MsgPort %p\n", process, msgPort));
+	D(bug("createSyncPortForThreadProcess(%p) -> MsgPort %p\n", process, msgPort));
 
 	if(msgPort)
 	{
@@ -345,7 +346,7 @@ static struct MsgPort* createSyncPortForProcess(APTR process)
 
 static void removeSyncPort(APTR syncPort)
 {
-	D(kprintf("removeSyncPort(%p)\n", syncPort));
+	D(bug("removeSyncPort(%p)\n", syncPort));
 
 	MutexLocker locker(syncPortMapMutex());
 
@@ -358,7 +359,7 @@ struct ThreadReplyState* threadReplyStateByThreadHandle(APTR threadHandle)
 {
 	MutexLocker locker(threadReplyStateMapMutex());
 
-	D(kprintf("threadReplyStateByThreadHandle(%p)\n", threadHandle));
+	D(bug("threadReplyStateByThreadHandle(%p)\n", threadHandle));
 
 	ThreadReplyStateMap::iterator i = threadReplyStateMap().begin();
 	for (; i != threadReplyStateMap().end(); ++i)
@@ -374,7 +375,7 @@ struct ThreadReplyState* threadReplyStateByThreadStartMsg(APTR threadStartMsg)
 {
 	MutexLocker locker(threadReplyStateMapMutex());
 
-	D(kprintf("threadReplyStateByThreadStartMsg(%p)\n", threadStartMsg));
+	D(bug("threadReplyStateByThreadStartMsg(%p)\n", threadStartMsg));
 
 	ThreadReplyStateMap::iterator i = threadReplyStateMap().begin();
 	for (; i != threadReplyStateMap().end(); ++i)
@@ -393,7 +394,7 @@ static ThreadReplyState* createThreadReplyState(struct ThreadData *threadHandle,
 
 	struct ThreadReplyState *threadReplyState = (struct ThreadReplyState *) malloc(sizeof(*threadReplyState));
 
-	D(kprintf("createReplyState(%p, %p) -> %p\n", threadHandle, threadStartMsg, threadReplyState));
+	D(bug("createReplyState(%p, %p) -> %p\n", threadHandle, threadStartMsg, threadReplyState));
 
 	if(threadReplyState)
 	{
@@ -412,7 +413,7 @@ static void removeThreadReplyState(ThreadReplyState *threadReplyState)
 {
 	MutexLocker locker(threadReplyStateMapMutex());
 
-	D(kprintf("removeThreadReplyState(%p)\n", threadReplyState));
+	D(bug("removeThreadReplyState(%p)\n", threadReplyState));
 
 	threadReplyStateMap().remove(threadReplyState);
 }
@@ -422,7 +423,7 @@ int	pendingChildrenForThread(APTR process)
 	int count = 0;
 	MutexLocker locker(threadReplyStateMapMutex());
 
-	D(kprintf("pendingChildrenForThread(%p)\n", process));
+	D(bug("pendingChildrenForThread(%p)\n", process));
 
 	ThreadReplyStateMap::iterator i = threadReplyStateMap().begin();
 	for (; i != threadReplyStateMap().end(); ++i)
@@ -439,7 +440,7 @@ int	pendingChildrenForThread(APTR process)
 
 ThreadIdentifier createThreadInternal(ThreadFunction entryPoint, void* data, const char* threadName)
 {
-	D(kprintf("createThreadInternal(%s)\n", threadName));
+	D(bug("createThreadInternal(%s)\n", threadName));
 
 	struct ThreadData* threadHandle = (struct ThreadData *) malloc(sizeof(*threadHandle));
 
@@ -512,7 +513,7 @@ ThreadIdentifier createThreadInternal(ThreadFunction entryPoint, void* data, con
 
 void initializeCurrentThreadInternal(const char* threadName)
 {
-	D(kprintf("setThreadNameInternal(%s)\n", threadName));
+	D(bug("setThreadNameInternal(%s)\n", threadName));
 }
 
 int waitForThreadCompletion(ThreadIdentifier threadID)
@@ -521,7 +522,7 @@ int waitForThreadCompletion(ThreadIdentifier threadID)
 
 	struct ThreadData *threadHandle = (struct ThreadData *) threadHandleForIdentifier(threadID);
 
-	D(kprintf("waitForThreadCompletion(%lu) -> threadHandle %p\n", threadID, threadHandle));
+	D(bug("waitForThreadCompletion(%lu) -> threadHandle %p\n", threadID, threadHandle));
 
 	// If the thread was detached, don't wait
 	if(threadHandle && !threadHandle->td_Detached)
@@ -529,11 +530,11 @@ int waitForThreadCompletion(ThreadIdentifier threadID)
 		ULONG processed = FALSE;
 		struct ThreadReplyState *threadReplyState = threadReplyStateByThreadHandle(threadHandle);
 
-		D(kprintf("Matching threadreplystate %p\n", threadReplyState));
+		D(bug("Matching threadreplystate %p\n", threadReplyState));
 		// First check if the thread didn't already complete
 		if(threadReplyState && threadReplyState->trs_Replied)
 		{
-			D(kprintf("Already replied\n"));
+			D(bug("Already replied\n"));
 			processed = TRUE;
 		}
 
@@ -544,7 +545,7 @@ int waitForThreadCompletion(ThreadIdentifier threadID)
 			{
 				struct ThreadStartMsg* tsm;
 
-				D(kprintf("Waiting for startupmsg\n"));
+				D(bug("Waiting for startupmsg\n"));
 				WaitPort(threadHandle->td_MsgPort);
 				tsm = (struct ThreadStartMsg*) GetMsg(threadHandle->td_MsgPort);
 
@@ -558,13 +559,13 @@ int waitForThreadCompletion(ThreadIdentifier threadID)
 						// It's the one we're waiting for.
 						if(threadReplyState->trs_ThreadHandle == threadHandle)
 						{
-							D(kprintf("Our thread, proceed\n"));
+							D(bug("Our thread, proceed\n"));
 							processed = TRUE;
 						}
 						// It's not. Mark it as replied and keep waiting
 						else
 						{
-							D(kprintf("Not our thread, marking as replied\n"));
+							D(bug("Not our thread, marking as replied\n"));
 							threadReplyState->trs_Replied = TRUE;
 						}
 					}
@@ -583,12 +584,12 @@ int waitForThreadCompletion(ThreadIdentifier threadID)
 
 		threadReplyStateMapMutex().lock();
 		int remaining = pendingChildrenForThread(FindTask(NULL));
-		D(kprintf("Remaining children %d\n", remaining));
+		D(bug("Remaining children %d\n", remaining));
 		if(remaining == 0)
 		{
 			// No more child thread, then we can delete the message port.
 			removeSyncPort(threadHandle->td_MsgPort);
-			D(kprintf("DeleteMsgPort(%p)\n", threadHandle->td_MsgPort));
+			D(bug("DeleteMsgPort(%p)\n", threadHandle->td_MsgPort));
 			DeleteMsgPort(threadHandle->td_MsgPort);
 		}
 		threadReplyStateMapMutex().unlock();
@@ -598,14 +599,14 @@ int waitForThreadCompletion(ThreadIdentifier threadID)
 		free(threadHandle);
 	}
 
-	D(kprintf("waitForThreadCompletion(%lu) OK\n", threadID));
+	D(bug("waitForThreadCompletion(%lu) OK\n", threadID));
 
 	return 0;
 }
 
 void waitForDetachedThreads()
 {
-	kprintf("waitForDetachedThreads() (probably doesn't work)\n");
+	bug("waitForDetachedThreads() (probably doesn't work)\n");
 
 	MutexLocker locker(threadMapMutex());
 
@@ -616,16 +617,16 @@ void waitForDetachedThreads()
 
 		if (threadHandle && threadHandle->td_Detached)
 		{
-			kprintf("Found detached thread\n");
+			bug("Found detached thread\n");
 
 			ULONG processed = FALSE;
 			struct ThreadReplyState *threadReplyState = threadReplyStateByThreadHandle(threadHandle);
 
-			D(kprintf("Matching threadreplystate %p\n", threadReplyState));
+			D(bug("Matching threadreplystate %p\n", threadReplyState));
 			// First check if the thread didn't already complete
 			if(threadReplyState && threadReplyState->trs_Replied)
 			{
-				D(kprintf("Already replied\n"));
+				D(bug("Already replied\n"));
 				processed = TRUE;
 			}
 
@@ -636,7 +637,7 @@ void waitForDetachedThreads()
 				{
 					struct ThreadStartMsg* tsm;
 
-					D(kprintf("Waiting for startupmsg\n"));
+					D(bug("Waiting for startupmsg\n"));
 					WaitPort(threadHandle->td_MsgPort);
 					tsm = (struct ThreadStartMsg*) GetMsg(threadHandle->td_MsgPort);
 
@@ -650,13 +651,13 @@ void waitForDetachedThreads()
 							// It's the one we're waiting for.
 							if(threadReplyState->trs_ThreadHandle == threadHandle)
 							{
-								D(kprintf("Our thread, proceed\n"));
+								D(bug("Our thread, proceed\n"));
 								processed = TRUE;
 							}
 							// It's not. Mark it as replied and keep waiting
 							else
 							{
-								D(kprintf("Not our thread, marking as replied\n"));
+								D(bug("Not our thread, marking as replied\n"));
 								threadReplyState->trs_Replied = TRUE;
 							}
 						}
@@ -670,12 +671,12 @@ void waitForDetachedThreads()
 
 			threadReplyStateMapMutex().lock();
 			int remaining = pendingChildrenForThread(FindTask(NULL));
-			D(kprintf("Remaining children %d\n", remaining));
+			D(bug("Remaining children %d\n", remaining));
 			if(remaining == 0)
 			{
 				// No more child thread, then we can delete the message port.
 				removeSyncPort(threadHandle->td_MsgPort);
-				D(kprintf("DeleteMsgPort(%p)\n", threadHandle->td_MsgPort));
+				D(bug("DeleteMsgPort(%p)\n", threadHandle->td_MsgPort));
 				DeleteMsgPort(threadHandle->td_MsgPort);
 			}
 			threadReplyStateMapMutex().unlock();
@@ -690,7 +691,7 @@ void waitForDetachedThreads()
 
 void detachThread(ThreadIdentifier threadID)
 {
-	kprintf("detachThread() (probably doesn't work)\n");
+	D(bug("detachThread() (probably doesn't work)\n"));
 
 	struct ThreadData *threadHandle = (struct ThreadData *) threadHandleForIdentifier(threadID);
 
@@ -706,7 +707,7 @@ ThreadIdentifier currentThread()
 	struct ThreadData *threadHandle;
 	APTR currentThread = FindTask(NULL);
 
-	D(kprintf("currentThread() task %p\n", currentThread));
+	D(bug("currentThread() task %p\n", currentThread));
 
 	if (ThreadIdentifier id = identifierByThread(currentThread))
 		return id;
@@ -727,7 +728,7 @@ ThreadIdentifier currentThread()
 
 bool isMainThread()
 {
-	D(kprintf("isMainThread() %d\n", currentThread() == mainThreadIdentifier));
+	D(bug("isMainThread() %d\n", currentThread() == mainThreadIdentifier));
 	return currentThread() == mainThreadIdentifier;
 }
 
@@ -818,7 +819,7 @@ ThreadCondition::ThreadCondition()
 {
 	struct _Condition *c;
 
-	D2(kprintf("ThreadCondition::ThreadCondition()\n"));
+	D2(bug("ThreadCondition::ThreadCondition()\n"));
 
 	/* allocate */
 	if ((c = (struct _Condition *)  AllocMem(sizeof(struct _Condition), MEMF_PUBLIC)))
@@ -830,14 +831,14 @@ ThreadCondition::ThreadCondition()
 		c->count = 0;
 	}
 
-	D2(kprintf("ThreadCondition::ThreadCondition() OK\n"));
+	D2(bug("ThreadCondition::ThreadCondition() OK\n"));
 }
 
 ThreadCondition::~ThreadCondition()
 {
 	struct _Condition *c = (struct _Condition *) m_condition;
 
-	D2(kprintf("ThreadCondition::~ThreadCondition()\n"));
+	D2(bug("ThreadCondition::~ThreadCondition()\n"));
 
 	if(c)
 	{
@@ -852,7 +853,7 @@ ThreadCondition::~ThreadCondition()
 		FreeMem(c, sizeof(struct _Condition));
 	}
 
-	D2(kprintf("ThreadCondition::~ThreadCondition() OK\n"));
+	D2(bug("ThreadCondition::~ThreadCondition() OK\n"));
 }
 
 void ThreadCondition::wait(Mutex & mutex)
@@ -860,7 +861,7 @@ void ThreadCondition::wait(Mutex & mutex)
 	struct _Condition *c = (struct _Condition *) m_condition;
 	struct _CondWaiter *waiter;
 
-	D2(kprintf("ThreadCondition::wait()\n"));
+	D2(bug("ThreadCondition::wait()\n"));
 
 	/* setup a new waiter */
 	if ((waiter = (struct _CondWaiter *) AllocMem(sizeof(struct _CondWaiter), MEMF_CLEAR)) == NULL)
@@ -894,7 +895,7 @@ void ThreadCondition::wait(Mutex & mutex)
 	/* retake the mutex */
 	mutex.lock();
 
-	D2(kprintf("ThreadCondition::wait() OK\n"));
+	D2(bug("ThreadCondition::wait() OK\n"));
 }
 
 bool ThreadCondition::timedWait(Mutex& mutex, double absoluteTime)
@@ -904,7 +905,7 @@ bool ThreadCondition::timedWait(Mutex& mutex, double absoluteTime)
 	bool conditionHit = false;
 	double interval = absoluteTime - currentTime();
 
-	D2(kprintf("ThreadCondition::timedWait()\n"));
+	D2(bug("ThreadCondition::timedWait()\n"));
 
 	if (interval < 0.0)
 		return false;
@@ -977,7 +978,7 @@ bool ThreadCondition::timedWait(Mutex& mutex, double absoluteTime)
 	/* retake the mutex */
 	mutex.lock();
 
-	D2(kprintf("ThreadCondition::timedWait() caught signal: %d\n", conditionHit));
+	D2(bug("ThreadCondition::timedWait() caught signal: %d\n", conditionHit));
 
 	return conditionHit;
 }
@@ -987,7 +988,7 @@ void ThreadCondition::signal()
 	struct _Condition *c = (struct _Condition *) m_condition;
 	struct _CondWaiter *waiter;
 
-	D2(kprintf("ThreadCondition::signal()\n"));
+	D2(bug("ThreadCondition::signal()\n"));
 
 	/* safely remove a waiter from the list */
 	ObtainSemaphore(&c->lock);
@@ -1006,7 +1007,7 @@ void ThreadCondition::signal()
 	/* all done */
 	FreeMem(waiter, sizeof(struct _CondWaiter));
 
-	D2(kprintf("ThreadCondition::signal() OK\n"));
+	D2(bug("ThreadCondition::signal() OK\n"));
 }
 
 void ThreadCondition::broadcast()
@@ -1014,7 +1015,7 @@ void ThreadCondition::broadcast()
 	struct _Condition *c = (struct _Condition *) m_condition;
 	struct _CondWaiter *waiter;
 
-	D2(kprintf("ThreadCondition::broadcast()\n"));
+	D2(bug("ThreadCondition::broadcast()\n"));
 
 	/* safely operation on the condition */
 	ObtainSemaphore(&c->lock);

--- a/odyssey-r155188-1.23/BAL/Types/WebCore/Common/BCBALValueCommon.cpp
+++ b/odyssey-r155188-1.23/BAL/Types/WebCore/Common/BCBALValueCommon.cpp
@@ -42,7 +42,12 @@
 #include "runtime_object.h"
 #include "runtime_array.h"
 
-#include <clib/debug_protos.h>
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 using namespace JSC;
 
@@ -184,7 +189,7 @@ JSObject* BALValue::toJSObject(ExecState* exec) const
 
 JSValue BALValue::toJSValue(ExecState* exec) const
 {
-    kprintf("BALValue::toJSValue() called\n");
+    D(bug("BALValue::toJSValue() called\n"));
     if (isJSObject() || isBALObject())
         return toJSObject(exec);
     else if (isArray())
@@ -250,13 +255,11 @@ void BALValue::balArray(BALArray* array)
     m_array = array;
 }
 
-#include <clib/debug_protos.h>
-
 void BALValue::balException(short code, const String& name, const String& description)
 {
-  kprintf("BALValue::balException\n");
+  D(bug("BALValue::balException\n"));
 #warning "bug bug bug"
-    kprintf("!!!! balException skipped %d %s %s\n", code, name.utf8().data(), description.utf8().data());
+    D(bug("!!!! balException skipped %d %s %s\n", code, name.utf8().data(), description.utf8().data()));
 
     /*
     // FIXME: This is stupid to convert the String to a char* (and strdup it!) to have it converted again in DOMCoreException but WebCore does not let us any choice here.

--- a/odyssey-r155188-1.23/BAL/Types/WebCore/MorphOS/BCIconMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Types/WebCore/MorphOS/BCIconMorphOS.cpp
@@ -37,7 +37,6 @@
 #include "BitmapImage.h"
 
 #include <cstdio>
-#include <clib/debug_protos.h>
 #include "../../../../WebKit/OrigynWebBrowser/Api/MorphOS/utils.h"
 
 namespace WebCore {

--- a/odyssey-r155188-1.23/BAL/Types/WebCore/MorphOS/BCKURLMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Types/WebCore/MorphOS/BCKURLMorphOS.cpp
@@ -31,8 +31,6 @@
 #include "WTFString.h"
 #include "CString.h"
 
-#include <clib/debug_protos.h>
-
 namespace WebCore {
 
 String KURL::fileSystemPath() const

--- a/odyssey-r155188-1.23/BAL/Types/WebCore/MorphOS/BCRefPtrMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Types/WebCore/MorphOS/BCRefPtrMorphOS.cpp
@@ -21,6 +21,13 @@
 
 #include <glib.h>
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
 namespace WTF {
 
 template <> GHashTable* refPlatformPtr(GHashTable* ptr)
@@ -56,13 +63,13 @@ typedef struct _GVariant {
 
 template <> GVariant* refPlatformPtr(GVariant* ptr)
 {
-    kprintf("refPlatformPtr for GVariant called\n");
+    D(bug("refPlatformPtr for GVariant called\n"));
     return ptr;
 }
 
 template <> void derefPlatformPtr(GVariant* ptr)
 {
-    kprintf("derefPlatformPtr for GVariantcalled\n");
+    D(bug("derefPlatformPtr for GVariantcalled\n"));
 }
 
 #endif

--- a/odyssey-r155188-1.23/BAL/Types/WebCore/MorphOS/BCRefPtrMorphOS.h
+++ b/odyssey-r155188-1.23/BAL/Types/WebCore/MorphOS/BCRefPtrMorphOS.h
@@ -23,6 +23,7 @@
 #ifndef WTF_GRefPtr_h
 #define WTF_GRefPtr_h
 
+#include "config.h"
 #include "AlwaysInline.h"
 #include "PlatformRefPtr.h"
 #include <algorithm>
@@ -33,14 +34,19 @@ typedef void* gpointer;
 extern "C" void g_object_unref(gpointer object); 
 extern "C" gpointer g_object_ref_sink(gpointer object); 
 
-#include <clib/debug_protos.h>
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 namespace WTF {
 
 
 template <typename T> inline T* refPlatformPtr(T* ptr)
 {
-    kprintf("refPlatformPtr for g_object called\n");
+    D(bug("refPlatformPtr for g_object called\n"));
     if (ptr)
         g_object_ref_sink(ptr);
     return ptr;
@@ -48,7 +54,7 @@ template <typename T> inline T* refPlatformPtr(T* ptr)
 
 template <typename T> inline void derefPlatformPtr(T* ptr)
 {
-    kprintf("derefPlatformPtr for g_object called\n");
+    D(bug("derefPlatformPtr for g_object called\n"));
     if (ptr)
         g_object_unref(ptr);
 }

--- a/odyssey-r155188-1.23/BAL/Types/WebCore/MorphOS/BCSharedBufferMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Types/WebCore/MorphOS/BCSharedBufferMorphOS.cpp
@@ -30,7 +30,13 @@
 #include "SharedBuffer.h"
 #include "FileIO.h"
 #include "CString.h"
-#include <clib/debug_protos.h>
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 namespace WebCore {
 
@@ -58,7 +64,7 @@ PassRefPtr<SharedBuffer> SharedBuffer::createWithContentsOfFile(const String& fi
         LOG_ERROR("Failed to properly create shared buffer");
         result->m_buffer.clear();
         result = 0;
-	kprintf("huho\n");
+	D(bug("huho\n"));
 	}*/
     delete fileData;
     return result.release();

--- a/odyssey-r155188-1.23/BAL/Widgets/WebCore/MorphOS/BCContextMenuMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Widgets/WebCore/MorphOS/BCContextMenuMorphOS.cpp
@@ -35,7 +35,6 @@
 #include <libraries/mui.h>
 #include <proto/muimaster.h>
 #include <clib/alib_protos.h>
-#include <clib/debug_protos.h>
 
 #include <cstdio>
 

--- a/odyssey-r155188-1.23/BAL/Widgets/WebCore/MorphOS/BCDragControllerMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Widgets/WebCore/MorphOS/BCDragControllerMorphOS.cpp
@@ -42,8 +42,6 @@
 
 #include <cstdio>
 
-#include <clib/debug_protos.h>
-
 namespace WebCore {
 
 // FIXME: These values are straight out of DragControllerMac, so probably have

--- a/odyssey-r155188-1.23/BAL/Widgets/WebCore/MorphOS/BCPasteboardMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Widgets/WebCore/MorphOS/BCPasteboardMorphOS.cpp
@@ -68,6 +68,11 @@
 
 #undef String
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 namespace WebCore {
@@ -134,43 +139,43 @@ enum ClipboardDataType {
 
 PassOwnPtr<Pasteboard> Pasteboard::create(int clipboard)
 {
-	D(kprintf("Pasteboard::create(clipboard=%d)\n", clipboard));
+	D(bug("Pasteboard::create(clipboard=%d)\n", clipboard));
 	return adoptPtr(new Pasteboard(clipboard));
 }
 
 PassOwnPtr<Pasteboard> Pasteboard::create(PassRefPtr<DataObjectMorphOS> dataObject, int clipboard)
 {
-	D(kprintf("Pasteboard::create(dataobject %p clipboard %d)\n", dataObject.get(), clipboard));
+	D(bug("Pasteboard::create(dataobject %p clipboard %d)\n", dataObject.get(), clipboard));
     return adoptPtr(new Pasteboard(dataObject, clipboard));
 }
 
 PassOwnPtr<Pasteboard> Pasteboard::createForCopyAndPaste()
 {
-	D(kprintf("Pasteboard::createForCopyAndPaste\n"));
+	D(bug("Pasteboard::createForCopyAndPaste\n"));
 	return create(0);
 }
 
 PassOwnPtr<Pasteboard> Pasteboard::createForGlobalSelection()
 {
-	D(kprintf("Pasteboard::createForGlobalSelection\n"));
+	D(bug("Pasteboard::createForGlobalSelection\n"));
 	return create(0);
 }
 
 PassOwnPtr<Pasteboard> Pasteboard::createPrivate()
 {
-	D(kprintf("Pasteboard::createPrivate\n"));
+	D(bug("Pasteboard::createPrivate\n"));
 	return create(DataObjectMorphOS::create());
 }
 
 PassOwnPtr<Pasteboard> Pasteboard::createForDragAndDrop()
 {
-	D(kprintf("Pasteboard::createForDragAndDrop\n"));
+	D(bug("Pasteboard::createForDragAndDrop\n"));
 	return create(DataObjectMorphOS::create(), 1);
 }
 
 PassOwnPtr<Pasteboard> Pasteboard::createForDragAndDrop(const DragData& dragData)
 {
-	D(kprintf("Pasteboard::createForDragAndDrop(dragData)\n"));
+	D(bug("Pasteboard::createForDragAndDrop(dragData)\n"));
 	return create(dragData.platformData(), 1);
 }
 
@@ -178,7 +183,7 @@ Pasteboard::Pasteboard(PassRefPtr<DataObjectMorphOS> dataObject, int clipboard)
     : m_dataObject(dataObject)
 	, m_morphosClipboard(clipboard)
 {
-	D(kprintf("Pasteboard::Pasteboard(dataObject %p, clipboard %d)\n", dataObject.get(), clipboard));
+	D(bug("Pasteboard::Pasteboard(dataObject %p, clipboard %d)\n", dataObject.get(), clipboard));
     ASSERT(m_dataObject);
 }
 
@@ -186,7 +191,7 @@ Pasteboard::Pasteboard(int clipboard)
 	: m_dataObject(DataObjectMorphOS::forClipboard(clipboard))
 	, m_morphosClipboard(clipboard)
 {
-	D(kprintf("Pasteboard::Pasteboard(clipboard %d)\n", clipboard));
+	D(bug("Pasteboard::Pasteboard(clipboard %d)\n", clipboard));
     ASSERT(m_dataObject);
 }
 
@@ -203,7 +208,7 @@ static ClipboardDataType dataObjectTypeFromHTMLClipboardType(const String& rawTy
 {
     String type(rawType.stripWhiteSpace());
 
-	D(kprintf("dataObjectTypeFromHTMLClipboardType %s\n", type.utf8().data()));
+	D(bug("dataObjectTypeFromHTMLClipboardType %s\n", type.utf8().data()));
 
     // Two special cases for IE compatibility
     if (type == "Text" || type == "text")
@@ -226,7 +231,7 @@ static ClipboardDataType dataObjectTypeFromHTMLClipboardType(const String& rawTy
 
 bool Pasteboard::writeString(const String& type, const String& data)
 {
-	D(kprintf("Pasteboard::writeString %s %s\n", type.utf8().data(), data.utf8().data()));
+	D(bug("Pasteboard::writeString %s %s\n", type.utf8().data(), data.utf8().data()));
 
     switch (dataObjectTypeFromHTMLClipboardType(type)) {
     case ClipboardDataTypeURIList:
@@ -269,7 +274,7 @@ void Pasteboard::writeSelection(Range* selectedRange, bool canSmartCopyOrDelete,
 {
 	String text = shouldSerializeSelectedTextForClipboard == IncludeImageAltTextForClipboard ? frame->editor().selectedTextForClipboard() : frame->editor().selectedText();
 
-	D(kprintf("Pasteboard::writeSelection %s %d\n", text.utf8().data(), m_morphosClipboard));
+	D(bug("Pasteboard::writeSelection %s %d\n", text.utf8().data(), m_morphosClipboard));
 
 	if(m_morphosClipboard == 0)
 	{
@@ -287,7 +292,7 @@ void Pasteboard::writeSelection(Range* selectedRange, bool canSmartCopyOrDelete,
 
 void Pasteboard::writePlainText(const String& text, SmartReplaceOption smartReplaceOption)
 {
-	D(kprintf("Pasteboard::writePlainText %s %d\n", text.utf8().data(), m_morphosClipboard));
+	D(bug("Pasteboard::writePlainText %s %d\n", text.utf8().data(), m_morphosClipboard));
 
 	if(m_morphosClipboard == 0)
 	{
@@ -304,7 +309,7 @@ void Pasteboard::writePlainText(const String& text, SmartReplaceOption smartRepl
 
 void Pasteboard::writeURL(const KURL& url, const String& label, Frame* frame)
 {
-	D(kprintf("Pasteboard::writeURL %s %d\n", url.string().utf8().data(), m_morphosClipboard));
+	D(bug("Pasteboard::writeURL %s %d\n", url.string().utf8().data(), m_morphosClipboard));
 
     ASSERT(!url.isEmpty());
 
@@ -342,7 +347,7 @@ void Pasteboard::writeImage(Node* node, const KURL&, const String& title)
 {
     ASSERT(node);
 
-	D(kprintf("Pasteboard::writeImage\n"));
+	D(bug("Pasteboard::writeImage\n"));
 
     if (!(node->renderer() && node->renderer()->isImage()))
         return;
@@ -384,7 +389,7 @@ void Pasteboard::writeImage(Node* node, const KURL&, const String& title)
     m_dataObject->clearAll();
 
     KURL url = getURLForImageNode(node);
-	D(kprintf("Pasteboard::writeImage url %s %d\n", url.string().utf8().data(), m_morphosClipboard));
+	D(bug("Pasteboard::writeImage url %s %d\n", url.string().utf8().data(), m_morphosClipboard));
     if (!url.isEmpty()) {
         m_dataObject->setURL(url, title);
         m_dataObject->setMarkup(createMarkup(toElement(node), IncludeNode, 0, ResolveAllURLs));
@@ -395,7 +400,7 @@ void Pasteboard::writeImage(Node* node, const KURL&, const String& title)
 
 void Pasteboard::writePasteboard(const Pasteboard& sourcePasteboard)
 {
-	D(kprintf("Pasteboard::writePasteboard\n"));
+	D(bug("Pasteboard::writePasteboard\n"));
 
 	RefPtr<DataObjectMorphOS> sourceDataObject = sourcePasteboard.dataObject();
     m_dataObject->clearAll();
@@ -420,7 +425,7 @@ void Pasteboard::writePasteboard(const Pasteboard& sourcePasteboard)
 
 void Pasteboard::clear()
 {
-	D(kprintf("Pasteboard::clear\n"));
+	D(bug("Pasteboard::clear\n"));
 
     // We do not clear filenames. According to the spec: "The clearData() method
     // does not affect whether any files were included in the drag, so the types
@@ -433,7 +438,7 @@ void Pasteboard::clear()
 
 void Pasteboard::clear(const String& type)
 {
-	D(kprintf("Pasteboard::clear(%s)\n", type.utf8().data()));
+	D(bug("Pasteboard::clear(%s)\n", type.utf8().data()));
 
     switch (dataObjectTypeFromHTMLClipboardType(type)) {
     case ClipboardDataTypeURIList:
@@ -471,7 +476,7 @@ static void setWithClipboardContents(Pasteboard *pasteboard, int clipboard)
 
 void Pasteboard::setDragImage(DragImageRef, const IntPoint& hotSpot)
 {
-	D(kprintf("Pasteboard::setDragImage()\n"));
+	D(bug("Pasteboard::setDragImage()\n"));
 }
 
 PassRefPtr<DocumentFragment> Pasteboard::documentFragment(Frame* frame, PassRefPtr<Range> context,
@@ -479,7 +484,7 @@ PassRefPtr<DocumentFragment> Pasteboard::documentFragment(Frame* frame, PassRefP
 {
 #warning "XXX: what to do here, exactly?"
 
-	D(kprintf("Pasteboard::documentFragment() allowPlainText %d\n", allowPlainText));
+	D(bug("Pasteboard::documentFragment() allowPlainText %d\n", allowPlainText));
 
 	setWithClipboardContents(this, m_morphosClipboard);
 	
@@ -539,7 +544,7 @@ static void copycollection(String &str, CollectionItem* ci, uint32 codeSet)
 
 String Pasteboard::plainText(Frame* frame)
 {
-	D(kprintf("Pasteboard::plainText()\n"));
+	D(bug("Pasteboard::plainText()\n"));
 
     String result;
 
@@ -589,7 +594,7 @@ String Pasteboard::plainText(Frame* frame)
 
 bool Pasteboard::hasData()
 {
-	D(kprintf("Pasteboard::hasData()\n"));
+	D(bug("Pasteboard::hasData()\n"));
 
 	//setWithClipboardContents(this, m_morphosClipboard);
 
@@ -598,7 +603,7 @@ bool Pasteboard::hasData()
 
 Vector<String> Pasteboard::types()
 {
-	D(kprintf("Pasteboard::types()\n"));
+	D(bug("Pasteboard::types()\n"));
 
 	setWithClipboardContents(this, m_morphosClipboard);
 
@@ -625,7 +630,7 @@ Vector<String> Pasteboard::types()
 
 String Pasteboard::readString(const String& type)
 {
-	D(kprintf("Pasteboard::readString(%s)\n", type.utf8().data()));
+	D(bug("Pasteboard::readString(%s)\n", type.utf8().data()));
 
 	setWithClipboardContents(this, m_morphosClipboard);
 
@@ -648,7 +653,7 @@ String Pasteboard::readString(const String& type)
 
 Vector<String> Pasteboard::readFilenames()
 {
-	D(kprintf("Pasteboard::readFilenames()\n"));
+	D(bug("Pasteboard::readFilenames()\n"));
 
 	setWithClipboardContents(this, m_morphosClipboard);
 

--- a/odyssey-r155188-1.23/BAL/Widgets/WebCore/MorphOS/BCRenderThemeMorphOS.cpp
+++ b/odyssey-r155188-1.23/BAL/Widgets/WebCore/MorphOS/BCRenderThemeMorphOS.cpp
@@ -42,7 +42,11 @@
 
 #include <proto/dos.h>
 
-#include <clib/debug_protos.h>
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 extern char *utf8_to_local(const char *);

--- a/odyssey-r155188-1.23/Base/config.h
+++ b/odyssey-r155188-1.23/Base/config.h
@@ -3,6 +3,8 @@
 
 #include "aos4funcs_base.h"
 
+#include "debug.h"
+
 #include "../../Source/JavaScriptCore/config.h"
 
 #include "../../WebCore/config.h"

--- a/odyssey-r155188-1.23/Base/debug.h
+++ b/odyssey-r155188-1.23/Base/debug.h
@@ -1,0 +1,20 @@
+#ifndef ODYSSEY_DEBUG_H
+#define ODYSSEY_DEBUG_H
+
+#if defined(__amigaos4__)
+  #include <proto/exec.h>
+  #define bug(fmt, args...)  {DebugPrintF("[%s:%ld %s] ", __FILE__, __LINE__, __FUNCTION__); DebugPrintF(fmt, ##args);}  
+#elif defined(__amigaos3__)
+  #include <clib/debug_protos.h>
+  #define bug(fmt, args...)  {kprintf("[%s:%ld] ", __FILE__, __LINE__); kprintf(fmt, ##args);}
+#elif defined(__MORPHOS__)
+  #include <clib/debug_protos.h>
+  #define bug(fmt, args...)  {kprintf("[%s:%ld %s] ", __FILE__, __LINE__, __FUNCTION__); kprintf(fmt, ##args);}
+#elif  defined(__AROS__)
+  #include <aros/debug.h>
+  #undef bug
+  #undef D
+  #define bug(fmt, args...)  {kprintf("[%s:%ld %s] ", __FILE__, __LINE__, __FUNCTION__); kprintf(fmt, ##args);}
+#endif
+
+#endif /* ODYSSEY_DEBUG_H */

--- a/odyssey-r155188-1.23/Source/JavaScriptCore/heap/BlockAllocator.cpp
+++ b/odyssey-r155188-1.23/Source/JavaScriptCore/heap/BlockAllocator.cpp
@@ -33,7 +33,6 @@
 #include <wtf/CurrentTime.h>
 #if OS(MORPHOS)
 #include <proto/dos.h>
-#include <clib/debug_protos.h>
 #undef Lock
 #endif
 

--- a/odyssey-r155188-1.23/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
+++ b/odyssey-r155188-1.23/Source/JavaScriptCore/heap/IncrementalSweeper.cpp
@@ -35,10 +35,12 @@
 #include <wtf/HashSet.h>
 #include <wtf/WTFThreadData.h>
 
-#if OS(MORPHOS)
-#include <clib/debug_protos.h>
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
-#endif
 
 namespace JSC {
 
@@ -111,7 +113,7 @@ void IncrementalSweeper::doWork()
 
 void IncrementalSweeper::doSweep(double sweepBeginTime)
 {
-    D(kprintf("IncrementalSweeper %d\n", m_blocksToSweep.size()));
+    D(bug("IncrementalSweeper %d\n", m_blocksToSweep.size()));
     while (m_currentBlockToSweepIndex < m_blocksToSweep.size()) {
         sweepNextBlock();
 
@@ -135,7 +137,7 @@ void IncrementalSweeper::sweepNextBlock()
         if (!block->needsSweeping())
             continue;
 
-	D(kprintf("block sweep\n"));
+	D(bug("block sweep\n"));
         block->sweep();
         m_vm->heap.objectSpace().freeOrShrinkBlock(block);
         return;

--- a/odyssey-r155188-1.23/Source/JavaScriptCore/heap/MachineStackMarker.cpp
+++ b/odyssey-r155188-1.23/Source/JavaScriptCore/heap/MachineStackMarker.cpp
@@ -32,8 +32,6 @@
 #if OS(MORPHOS)
 #include <proto/exec.h>
 #include <proto/dos.h>
-#include <clib/debug_protos.h>
-#define D(x)
 #endif
 
 #if OS(DARWIN)
@@ -76,6 +74,13 @@
 #endif
 
 #endif
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 using namespace WTF;
 
@@ -205,7 +210,7 @@ static inline bool equalThread(const PlatformThread& first, const PlatformThread
 
 void MachineThreads::makeUsableFromMultipleThreads()
 {
-    D(kprintf("makeUsableFromMultipleThreads\n"));
+    D(bug("makeUsableFromMultipleThreads\n"));
 
     if (m_threadSpecific)
         return;
@@ -231,14 +236,14 @@ void MachineThreads::addCurrentThread()
 
 void MachineThreads::removeThread(void* p)
 {
-    D(kprintf("removeThread\n"));
+    D(bug("removeThread\n"));
     if (p)
         static_cast<MachineThreads*>(p)->removeCurrentThread();
 }
 
 void MachineThreads::removeCurrentThread()
 {
-    D(kprintf("RemoveCurrentThread\n"));
+    D(bug("RemoveCurrentThread\n"));
 
     PlatformThread currentPlatformThread = getCurrentPlatformThread();
 
@@ -283,17 +288,17 @@ void MachineThreads::gatherFromCurrentThread(ConservativeRoots& conservativeRoot
 #if COMPILER(MSVC)
 #pragma warning(pop)
 #endif
-    D(kprintf("gatherFromCurrentThread\n"));
+    D(bug("gatherFromCurrentThread\n"));
 
     void* registersBegin = &registers;
     void* registersEnd = reinterpret_cast<void*>(roundUpToMultipleOf<sizeof(void*)>(reinterpret_cast<uintptr_t>(&registers + 1)));
-    D(kprintf("registersBegin %p registersEnd %p\n", registersBegin, registersEnd));
+    D(bug("registersBegin %p registersEnd %p\n", registersBegin, registersEnd));
     swapIfBackwards(registersBegin, registersEnd);
     conservativeRoots.add(registersBegin, registersEnd);
 
     void* stackBegin = stackCurrent;
     void* stackEnd = wtfThreadData().stack().origin();
-    D(kprintf("stackBegin %p stackEnd %p\n", stackBegin, stackEnd));
+    D(bug("stackBegin %p stackEnd %p\n", stackBegin, stackEnd));
     swapIfBackwards(stackBegin, stackEnd);
     conservativeRoots.add(stackBegin, stackEnd);
 }
@@ -552,7 +557,7 @@ static void freePlatformThreadRegisters(PlatformThreadRegisters& regs)
 
 void MachineThreads::gatherFromOtherThread(ConservativeRoots& conservativeRoots, Thread* thread)
 {
-    D(kprintf("gatherFromOtherThread\n"));
+    D(bug("gatherFromOtherThread\n"));
 
     PlatformThreadRegisters regs;
     size_t regSize = getPlatformThreadRegisters(thread->platformThread, regs);
@@ -571,8 +576,8 @@ void MachineThreads::gatherFromOtherThread(ConservativeRoots& conservativeRoots,
     swapIfBackwards(stackPointer, stackBase);
     conservativeRoots.add(stackPointer, stackBase);
 
-    D(kprintf("regs %p regSize %d\n", &regs, regSize));
-    D(kprintf("stackPointer %p stackBase %p\n", stackPointer, stackBase));
+    D(bug("regs %p regSize %d\n", &regs, regSize));
+    D(bug("stackPointer %p stackBase %p\n", stackPointer, stackBase));
 
     freePlatformThreadRegisters(regs);
 }
@@ -581,7 +586,7 @@ void MachineThreads::gatherFromOtherThread(ConservativeRoots& conservativeRoots,
 
 void MachineThreads::gatherConservativeRoots(ConservativeRoots& conservativeRoots, void* stackCurrent)
 {
-    D(kprintf("gatherConservativeRoots\n"));
+    D(bug("gatherConservativeRoots\n"));
 
     gatherFromCurrentThread(conservativeRoots, stackCurrent);
 

--- a/odyssey-r155188-1.23/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/odyssey-r155188-1.23/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -26,8 +26,6 @@
 #include "config.h"
 #include "LowLevelInterpreter.h"
 
-#include <clib/debug_protos.h>
-
 #if ENABLE(LLINT)
 
 #include "LLIntOfflineAsmConfig.h"

--- a/odyssey-r155188-1.23/Source/JavaScriptCore/runtime/DateConstructor.cpp
+++ b/odyssey-r155188-1.23/Source/JavaScriptCore/runtime/DateConstructor.cpp
@@ -48,10 +48,6 @@ extern "C" time_t time(time_t* timer); // Provided by libce.
 #include <sys/timeb.h>
 #endif
 
-#if OS(MORPHOS)
-#include <clib/debug_protos.h>
-#endif
-
 using namespace WTF;
 
 namespace JSC {

--- a/odyssey-r155188-1.23/Source/JavaScriptCore/runtime/DatePrototype.cpp
+++ b/odyssey-r155188-1.23/Source/JavaScriptCore/runtime/DatePrototype.cpp
@@ -66,7 +66,6 @@
 #include <unicode/udat.h>
 #endif
 
-#include <clib/debug_protos.h>
 #include <proto/exec.h>
 
 using namespace WTF;

--- a/odyssey-r155188-1.23/Source/JavaScriptCore/runtime/GCActivityCallbackMorphOS.cpp
+++ b/odyssey-r155188-1.23/Source/JavaScriptCore/runtime/GCActivityCallbackMorphOS.cpp
@@ -22,8 +22,11 @@
 #include "Heap.h"
 #include "VM.h"
 
-#include <clib/debug_protos.h>
-#include <proto/exec.h>
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 static char *noperiodicCollect = (char *) getenv("OWB_NO_PERIODIC_COLLECT"); 
@@ -39,7 +42,7 @@ DefaultGCActivityCallback::DefaultGCActivityCallback(Heap* heap)
 
 void DefaultGCActivityCallback::doWork()
 {
-    D(kprintf("DefaultGCActivityCallback::doWork\n"));
+    D(bug("DefaultGCActivityCallback::doWork\n"));
     JSLock lock();
     
     if(!noperiodicCollect)
@@ -51,18 +54,18 @@ void DefaultGCActivityCallback::doWork()
 
 void DefaultGCActivityCallback::didAllocate(size_t bytesAllocated)
 {
-    D(kprintf("DefaultGCActivityCallback::didAllocate(%lu) %f\n", bytesAllocated, m_vm->heap.lastGCLength()));
+    D(bug("DefaultGCActivityCallback::didAllocate(%lu) %f\n", bytesAllocated, m_vm->heap.lastGCLength()));
 
     if (m_timer.isActive())
         return;
     if(!noperiodicCollect)
     {
         double nextTime = 5*60; //m_globalData->heap.lastGCLength() * 200;
-	D(kprintf("next collect in %f s\n", nextTime));
+	D(bug("next collect in %f s\n", nextTime));
 
 	if((AvailMem(MEMF_ANY) + 32*1024*1024 < prev_availmem) || (AvailMem(MEMF_ANY) < 16*1024*1024))
 	{
-	    D(kprintf(">32MB memory was eaten since last collect, let's do it now\n"));
+	    D(bug(">32MB memory was eaten since last collect, let's do it now\n"));
 	    nextTime = 1;
 	}
 
@@ -72,14 +75,14 @@ void DefaultGCActivityCallback::didAllocate(size_t bytesAllocated)
 
 void DefaultGCActivityCallback::willCollect()
 {
-    D(kprintf("DefaultGCActivityCallback::willCollect\n"));
+    D(bug("DefaultGCActivityCallback::willCollect\n"));
     if(!noperiodicCollect)
         cancel();
 }
 
 void DefaultGCActivityCallback::cancel()
 {
-    D(kprintf("DefaultGCActivityCallback::cancel\n"));
+    D(bug("DefaultGCActivityCallback::cancel\n"));
     if(!noperiodicCollect)
         m_timer.stop();
 }

--- a/odyssey-r155188-1.23/Source/JavaScriptCore/runtime/JSDateMath.cpp
+++ b/odyssey-r155188-1.23/Source/JavaScriptCore/runtime/JSDateMath.cpp
@@ -101,9 +101,12 @@
 #include <sys/timeb.h>
 #endif
 
-#if OS(MORPHOS)
-#include <clib/debug_protos.h>
-#endif
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 using namespace WTF;
 
@@ -194,7 +197,7 @@ static LocalTimeOffset localTimeOffset(ExecState* exec, double ms)
 
 double gregorianDateTimeToMS(ExecState* exec, const GregorianDateTime& t, double milliSeconds, bool inputIsUTC)
 {
-    //kprintf("gregorianDateTimeToMS d %d m %d y %d ms %f\n", t.monthDay(), t.month(), t.year(), milliSeconds);
+    //D(bug("gregorianDateTimeToMS d %d m %d y %d ms %f\n", t.monthDay(), t.month(), t.year(), milliSeconds));
     double day = dateToDaysFrom1970(t.year(), t.month(), t.monthDay());
     double ms = timeToMS(t.hour(), t.minute(), t.second(), milliSeconds);
     double result = (day * WTF::msPerDay) + ms;
@@ -202,14 +205,14 @@ double gregorianDateTimeToMS(ExecState* exec, const GregorianDateTime& t, double
     if (!inputIsUTC)
         result -= localTimeOffset(exec, result).offset;
 
-    //kprintf("result %f\n", result);
+    //D(bug("result %f\n", result));
     return result;
 }
 
 // input is UTC
 void msToGregorianDateTime(ExecState* exec, double ms, bool outputIsUTC, GregorianDateTime& tm)
 {
-    //kprintf("msToGregorianDateTime ms %f currentTime %f\n", ms, currentTime());
+    //D(bug("msToGregorianDateTime ms %f currentTime %f\n", ms, currentTime()));
     LocalTimeOffset localTime;
     if (!outputIsUTC) {
         localTime = localTimeOffset(exec, ms);
@@ -227,7 +230,7 @@ void msToGregorianDateTime(ExecState* exec, double ms, bool outputIsUTC, Gregori
     tm.setYear(year);
     tm.setIsDST(localTime.isDST);
     tm.setUtcOffset(localTime.offset / WTF::msPerSecond);
-    //kprintf("result msToGregorianDateTime d %d m %d y %d\n", tm.monthDay(), tm.month(), tm.year());
+    //D(bug("result msToGregorianDateTime d %d m %d y %d\n", tm.monthDay(), tm.month(), tm.year()));
 }
 
 double parseDateFromNullTerminatedCharacters(ExecState* exec, const char* dateString)
@@ -238,12 +241,12 @@ double parseDateFromNullTerminatedCharacters(ExecState* exec, const char* dateSt
     double ms = WTF::parseDateFromNullTerminatedCharacters(dateString, haveTZ, offset);
     if (std::isnan(ms))
         return QNaN;
-    //kprintf("JSC::parseDateFromNullTerminatedCharacters ms %f haveTZ %d offset %d\n", ms, haveTZ, offset); 
+    //D(bug("JSC::parseDateFromNullTerminatedCharacters ms %f haveTZ %d offset %d\n", ms, haveTZ, offset)); 
     // fall back to local timezone
     if (!haveTZ)
         offset = localTimeOffset(exec, ms).offset / WTF::msPerMinute;
 
-    //kprintf("JSC::parseDateFromNullTerminatedCharacters offset %d\n", offset);
+    //D(bug("JSC::parseDateFromNullTerminatedCharacters offset %d\n", offset));
 
     return ms - (offset * WTF::msPerMinute);
 }

--- a/odyssey-r155188-1.23/Source/WTF/wtf/OSAllocatorMorphOS.cpp
+++ b/odyssey-r155188-1.23/Source/WTF/wtf/OSAllocatorMorphOS.cpp
@@ -29,20 +29,25 @@
 #include <wtf/FastMalloc.h>
 
 #include <string.h>
-#include <clib/debug_protos.h>
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 namespace WTF {
 
 void* OSAllocator::reserveUncommitted(size_t bytes, Usage, bool, bool, bool)
 {
-	D(kprintf("OSAllocator::reserveUncommitted(%lu)\n", bytes));
+	D(bug("OSAllocator::reserveUncommitted(%lu)\n", bytes));
 	return fastMalloc(bytes);
 }
 
 void* OSAllocator::reserveAndCommit(size_t bytes, Usage, bool, bool, bool)
 {
-	D(kprintf("OSAllocator::reserveAndCommit(%lu)\n", bytes));
+	D(bug("OSAllocator::reserveAndCommit(%lu)\n", bytes));
 	void *ptr =	fastMalloc(bytes);
 	if(ptr)
 	{
@@ -53,18 +58,18 @@ void* OSAllocator::reserveAndCommit(size_t bytes, Usage, bool, bool, bool)
 
 void OSAllocator::commit(void* address, size_t bytes, bool, bool)
 {
-	D(kprintf("OSAllocator::commit(%p, %lu)\n", address, bytes));
+	D(bug("OSAllocator::commit(%p, %lu)\n", address, bytes));
 	memset(address, 0, bytes);
 }
 
 void OSAllocator::decommit(void* address, size_t bytes)
 {
-	D(kprintf("OSAllocator::decommit(%p, %lu)\n", address, bytes));
+	D(bug("OSAllocator::decommit(%p, %lu)\n", address, bytes));
 }
 
 void OSAllocator::releaseDecommitted(void* address, size_t bytes)
 {
-	D(kprintf("OSAllocator::releaseDecommitted(%p, %lu)\n", address, bytes));
+	D(bug("OSAllocator::releaseDecommitted(%p, %lu)\n", address, bytes));
 	fastFree(address);
 }
 

--- a/odyssey-r155188-1.23/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/odyssey-r155188-1.23/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -30,9 +30,12 @@
 
 #include "config.h"
 
-#include <proto/exec.h>
-#define kprintf IExec->DebugPrintF 
-#define D(x) //#define D(x) x  to enalbed debug 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 #if ENABLE(WEB_SOCKETS)
 
@@ -217,7 +220,7 @@ void WebSocket::connect(const String& url, const String& protocol, ExceptionCode
 
 void WebSocket::connect(const String& url, const Vector<String>& protocols, ExceptionCode& ec)
 {
-    D(kprintf("WebSocket %p connect() url='%s'\n", this, url.utf8().data()));
+    D(bug("WebSocket %p connect() url='%s'\n", this, url.utf8().data()));
     m_url = KURL(KURL(), url);
 
     if (!m_url.isValid()) {
@@ -297,7 +300,7 @@ void WebSocket::connect(const String& url, const Vector<String>& protocols, Exce
 
 void WebSocket::send(const String& message, ExceptionCode& ec)
 {
-    D(kprintf("WebSocket %p send() Sending String '%s'\n", this, message.utf8().data()));
+    D(bug("WebSocket %p send() Sending String '%s'\n", this, message.utf8().data()));
     if (m_state == CONNECTING) {
         ec = INVALID_STATE_ERR;
         return;
@@ -320,7 +323,7 @@ void WebSocket::send(const String& message, ExceptionCode& ec)
 
 void WebSocket::send(ArrayBuffer* binaryData, ExceptionCode& ec)
 {
-    D(kprintf("WebSocket %p send() Sending ArrayBuffer %p\n", this, binaryData));
+    D(bug("WebSocket %p send() Sending ArrayBuffer %p\n", this, binaryData));
     ASSERT(binaryData);
     if (m_state == CONNECTING) {
         ec = INVALID_STATE_ERR;
@@ -338,7 +341,7 @@ void WebSocket::send(ArrayBuffer* binaryData, ExceptionCode& ec)
 
 void WebSocket::send(ArrayBufferView* arrayBufferView, ExceptionCode& ec)
 {
-    D(kprintf("WebSocket %p send() Sending ArrayBufferView %p\n", this, arrayBufferView));
+    D(bug("WebSocket %p send() Sending ArrayBufferView %p\n", this, arrayBufferView));
     ASSERT(arrayBufferView);
     if (m_state == CONNECTING) {
         ec = INVALID_STATE_ERR;
@@ -357,7 +360,7 @@ void WebSocket::send(ArrayBufferView* arrayBufferView, ExceptionCode& ec)
 
 void WebSocket::send(Blob* binaryData, ExceptionCode& ec)
 {
-    D(kprintf("WebSocket %p send() Sending Blob '%s'\n", this, binaryData->url().stringCenterEllipsizedToLength().utf8().data()));
+    D(bug("WebSocket %p send() Sending Blob '%s'\n", this, binaryData->url().stringCenterEllipsizedToLength().utf8().data()));
     ASSERT(binaryData);
     if (m_state == CONNECTING) {
         ec = INVALID_STATE_ERR;
@@ -376,9 +379,9 @@ void WebSocket::send(Blob* binaryData, ExceptionCode& ec)
 void WebSocket::close(int code, const String& reason, ExceptionCode& ec)
 {
     if (code == WebSocketChannel::CloseEventCodeNotSpecified)
-        D(kprintf("WebSocket %p close() without code and reason\n", this));
+        D(bug("WebSocket %p close() without code and reason\n", this));
     else {
-        D(kprintf("WebSocket %p close() code=%d reason='%s'\n", this, code, reason.utf8().data()));
+        D(bug("WebSocket %p close() code=%d reason='%s'\n", this, code, reason.utf8().data()));
         if (!(code == WebSocketChannel::CloseEventCodeNormalClosure || (WebSocketChannel::CloseEventCodeMinimumUserDefined <= code && code <= WebSocketChannel::CloseEventCodeMaximumUserDefined))) {
             ec = INVALID_ACCESS_ERR;
             return;
@@ -465,7 +468,7 @@ ScriptExecutionContext* WebSocket::scriptExecutionContext() const
 
 void WebSocket::contextDestroyed()
 {
-    D(kprintf("WebSocket %p contextDestroyed()\n", this));
+    D(bug("WebSocket %p contextDestroyed()\n", this));
     ASSERT(!m_channel);
     ASSERT(m_state == CLOSED);
     ActiveDOMObject::contextDestroyed();
@@ -502,7 +505,7 @@ void WebSocket::stop()
 
 void WebSocket::didConnect()
 {
-    D(kprintf("WebSocket %p didConnect()\n", this));
+    D(bug("WebSocket %p didConnect()\n", this));
     if (m_state != CONNECTING) {
         didClose(0, ClosingHandshakeIncomplete, WebSocketChannel::CloseEventCodeAbnormalClosure, "");
         return;
@@ -516,7 +519,7 @@ void WebSocket::didConnect()
 
 void WebSocket::didReceiveMessage(const String& msg)
 {
-    D(kprintf("WebSocket %p didReceiveMessage() Text message '%s'\n", this, msg.utf8().data()));
+    D(bug("WebSocket %p didReceiveMessage() Text message '%s'\n", this, msg.utf8().data()));
     if (m_state != OPEN)
         return;
     ASSERT(scriptExecutionContext());
@@ -525,7 +528,7 @@ void WebSocket::didReceiveMessage(const String& msg)
 
 void WebSocket::didReceiveBinaryData(PassOwnPtr<Vector<char> > binaryData)
 {
-    D(kprintf("WebSocket %p didReceiveBinaryData() %lu byte binary message\n", this, static_cast<unsigned long>(binaryData->size())));
+    D(bug("WebSocket %p didReceiveBinaryData() %lu byte binary message\n", this, static_cast<unsigned long>(binaryData->size())));
     switch (m_binaryType) {
     case BinaryTypeBlob: {
         size_t size = binaryData->size();
@@ -546,14 +549,14 @@ void WebSocket::didReceiveBinaryData(PassOwnPtr<Vector<char> > binaryData)
 
 void WebSocket::didReceiveMessageError()
 {
-    D(kprintf("WebSocket %p didReceiveErrorMessage()\n", this));
+    D(bug("WebSocket %p didReceiveErrorMessage()\n", this));
     ASSERT(scriptExecutionContext());
     dispatchEvent(Event::create(eventNames().errorEvent, false, false));
 }
 
 void WebSocket::didUpdateBufferedAmount(unsigned long bufferedAmount)
 {
-    D(kprintf("WebSocket %p didUpdateBufferedAmount() New bufferedAmount is %lu\n", this, bufferedAmount));
+    D(bug("WebSocket %p didUpdateBufferedAmount() New bufferedAmount is %lu\n", this, bufferedAmount));
     if (m_state == CLOSED)
         return;
     m_bufferedAmount = bufferedAmount;
@@ -561,13 +564,13 @@ void WebSocket::didUpdateBufferedAmount(unsigned long bufferedAmount)
 
 void WebSocket::didStartClosingHandshake()
 {
-    D(kprintf("WebSocket %p didStartClosingHandshake()\n", this));
+    D(bug("WebSocket %p didStartClosingHandshake()\n", this));
     m_state = CLOSING;
 }
 
 void WebSocket::didClose(unsigned long unhandledBufferedAmount, ClosingHandshakeCompletionStatus closingHandshakeCompletion, unsigned short code, const String& reason)
 {
-    D(kprintf("WebSocket %p didClose()\n", this));
+    D(bug("WebSocket %p didClose()\n", this));
     if (!m_channel)
         return;
     bool wasClean = m_state == CLOSING && !unhandledBufferedAmount && closingHandshakeCompletion == ClosingHandshakeComplete && code != WebSocketChannel::CloseEventCodeAbnormalClosure;

--- a/odyssey-r155188-1.23/Source/WebCore/Modules/websockets/WebSocketChannel.cpp
+++ b/odyssey-r155188-1.23/Source/WebCore/Modules/websockets/WebSocketChannel.cpp
@@ -30,9 +30,12 @@
 
 #include "config.h"
 
-#include <proto/exec.h>
-#define kprintf IExec->DebugPrintF
-#define D(x) //#define D(x) x  to enalbed debug 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 #if ENABLE(WEB_SOCKETS)
 
@@ -108,7 +111,7 @@ WebSocketChannel::~WebSocketChannel()
 
 void WebSocketChannel::connect(const KURL& url, const String& protocol)
 {
- 	D(kprintf("WebSocketChannel %p connect()\n", this));
+ 	D(bug("WebSocketChannel %p connect()\n", this));
 	
     ASSERT(!m_handle);
     ASSERT(!m_suspended);
@@ -124,7 +127,7 @@ void WebSocketChannel::connect(const KURL& url, const String& protocol)
 
 String WebSocketChannel::subprotocol()
 {
- 	D(kprintf("WebSocketChannel %p subprotocol()\n", this));
+ 	D(bug("WebSocketChannel %p subprotocol()\n", this));
     if (!m_handshake || m_handshake->mode() != WebSocketHandshake::Connected)
         return "";
     String serverProtocol = m_handshake->serverWebSocketProtocol();
@@ -135,7 +138,7 @@ String WebSocketChannel::subprotocol()
 
 String WebSocketChannel::extensions()
 {   
-	D(kprintf("WebSocketChannel %p extensions()\n", this));
+	D(bug("WebSocketChannel %p extensions()\n", this));
     if (!m_handshake || m_handshake->mode() != WebSocketHandshake::Connected)
         return "";
     String extensions = m_handshake->acceptedExtensions();
@@ -146,7 +149,7 @@ String WebSocketChannel::extensions()
 
 ThreadableWebSocketChannel::SendResult WebSocketChannel::send(const String& message)
 {
-	D(kprintf("WebSocketChannel %p send() Sending String '%s'\n", this, message.utf8().data()));
+	D(bug("WebSocketChannel %p send() Sending String '%s'\n", this, message.utf8().data()));
     CString utf8 = message.utf8(StrictConversionReplacingUnpairedSurrogatesWithFFFD);
     enqueueTextFrame(utf8);
     processOutgoingFrameQueue();
@@ -162,7 +165,7 @@ ThreadableWebSocketChannel::SendResult WebSocketChannel::send(const String& mess
 ThreadableWebSocketChannel::SendResult WebSocketChannel::send(const ArrayBuffer& binaryData, unsigned byteOffset, unsigned byteLength)
 {
     
-	D(kprintf("WebSocketChannel %p send() Sending ArrayBuffer %p byteOffset=%u byteLength=%u\n", this, &binaryData, byteOffset, byteLength));
+	D(bug("WebSocketChannel %p send() Sending ArrayBuffer %p byteOffset=%u byteLength=%u\n", this, &binaryData, byteOffset, byteLength));
     enqueueRawFrame(WebSocketFrame::OpCodeBinary, static_cast<const char*>(binaryData.data()) + byteOffset, byteLength);
     processOutgoingFrameQueue();
     return ThreadableWebSocketChannel::SendSuccess;
@@ -171,7 +174,7 @@ ThreadableWebSocketChannel::SendResult WebSocketChannel::send(const ArrayBuffer&
 ThreadableWebSocketChannel::SendResult WebSocketChannel::send(const Blob& binaryData)
 {
     
-	D(kprintf("WebSocketChannel %p send() Sending Blob '%s'\n", this, binaryData.url().stringCenterEllipsizedToLength().utf8().data()));
+	D(bug("WebSocketChannel %p send() Sending Blob '%s'\n", this, binaryData.url().stringCenterEllipsizedToLength().utf8().data()));
     enqueueBlobFrame(WebSocketFrame::OpCodeBinary, binaryData);
     processOutgoingFrameQueue();
     return ThreadableWebSocketChannel::SendSuccess;
@@ -180,7 +183,7 @@ ThreadableWebSocketChannel::SendResult WebSocketChannel::send(const Blob& binary
 bool WebSocketChannel::send(const char* data, int length)
 {
     
-	D(kprintf("WebSocketChannel %p send() Sending char* data=%p length=%d\n", this, data, length));
+	D(bug("WebSocketChannel %p send() Sending char* data=%p length=%d\n", this, data, length));
     enqueueRawFrame(WebSocketFrame::OpCodeBinary, data, length);
     processOutgoingFrameQueue();
     return true;
@@ -189,7 +192,7 @@ bool WebSocketChannel::send(const char* data, int length)
 unsigned long WebSocketChannel::bufferedAmount() const
 {
     
-	D(kprintf("WebSocketChannel %p bufferedAmount()\n", this));
+	D(bug("WebSocketChannel %p bufferedAmount()\n", this));
     ASSERT(m_handle);
     ASSERT(!m_suspended);
     return m_handle->bufferedAmount();
@@ -198,7 +201,7 @@ unsigned long WebSocketChannel::bufferedAmount() const
 void WebSocketChannel::close(int code, const String& reason)
 {
     
-	D(kprintf("WebSocketChannel %p close() code=%d reason='%s'\n", this, code, reason.utf8().data()));
+	D(bug("WebSocketChannel %p close() code=%d reason='%s'\n", this, code, reason.utf8().data()));
     ASSERT(!m_suspended);
     if (!m_handle)
         return;
@@ -210,7 +213,7 @@ void WebSocketChannel::close(int code, const String& reason)
 void WebSocketChannel::fail(const String& reason)
 {
     
-	D(kprintf("WebSocketChannel %p fail() reason='%s'\n", this, reason.utf8().data()));
+	D(bug("WebSocketChannel %p fail() reason='%s'\n", this, reason.utf8().data()));
     ASSERT(!m_suspended);
     if (m_document) {
         InspectorInstrumentation::didReceiveWebSocketFrameError(m_document, m_identifier, reason);
@@ -235,7 +238,7 @@ void WebSocketChannel::fail(const String& reason)
 void WebSocketChannel::disconnect()
 {
     
-	D(kprintf("WebSocketChannel %p disconnect()\n", this));
+	D(bug("WebSocketChannel %p disconnect()\n", this));
     if (m_identifier && m_document)
         InspectorInstrumentation::didCloseWebSocket(m_document, m_identifier);
     if (m_handshake)
@@ -260,7 +263,7 @@ void WebSocketChannel::resume()
 
 void WebSocketChannel::willOpenSocketStream(SocketStreamHandle* handle)
 {
-	D(kprintf("WebSocketChannel %p willOpenSocketStream()\n", this));
+	D(bug("WebSocketChannel %p willOpenSocketStream()\n", this));
     ASSERT(handle);
     if (m_document->frame())
         m_document->frame()->loader().client().dispatchWillOpenSocketStream(handle);
@@ -268,7 +271,7 @@ void WebSocketChannel::willOpenSocketStream(SocketStreamHandle* handle)
 
 void WebSocketChannel::didOpenSocketStream(SocketStreamHandle* handle)
 {    
-	D(kprintf("WebSocketChannel %p didOpenSocketStream()\n", this));
+	D(bug("WebSocketChannel %p didOpenSocketStream()\n", this));
     ASSERT(handle == m_handle);
     if (!m_document)
         return;
@@ -282,7 +285,7 @@ void WebSocketChannel::didOpenSocketStream(SocketStreamHandle* handle)
 void WebSocketChannel::didCloseSocketStream(SocketStreamHandle* handle)
 {
     
-	D(kprintf("WebSocketChannel %p didCloseSocketStream()\n", this));
+	D(bug("WebSocketChannel %p didCloseSocketStream()\n", this));
     if (m_identifier && m_document)
         InspectorInstrumentation::didCloseWebSocket(m_document, m_identifier);
     ASSERT_UNUSED(handle, handle == m_handle || !m_handle);
@@ -308,7 +311,7 @@ void WebSocketChannel::didCloseSocketStream(SocketStreamHandle* handle)
 void WebSocketChannel::didReceiveSocketStreamData(SocketStreamHandle* handle, const char* data, int len)
 {
     
-	D(kprintf("WebSocketChannel %p didReceiveSocketStreamData() Received %d bytes\n", this, len));
+	D(bug("WebSocketChannel %p didReceiveSocketStreamData() Received %d bytes\n", this, len));
     RefPtr<WebSocketChannel> protect(this); // The client can close the channel, potentially removing the last reference.
     ASSERT(handle == m_handle);
     if (!m_document) {
@@ -344,7 +347,7 @@ void WebSocketChannel::didUpdateBufferedAmount(SocketStreamHandle*, size_t buffe
 void WebSocketChannel::didFailSocketStream(SocketStreamHandle* handle, const SocketStreamError& error)
 {
     
-	D(kprintf("WebSocketChannel %p didFailSocketStream()\n", this));
+	D(bug("WebSocketChannel %p didFailSocketStream()\n", this));
     ASSERT(handle == m_handle || !m_handle);
     if (m_document) {
         String message;
@@ -373,21 +376,21 @@ void WebSocketChannel::didCancelAuthenticationChallenge(SocketStreamHandle*, con
 void WebSocketChannel::didStartLoading()
 {
     
-	D(kprintf("WebSocketChannel %p didStartLoading()\n", this));
+	D(bug("WebSocketChannel %p didStartLoading()\n", this));
     ASSERT(m_blobLoader);
     ASSERT(m_blobLoaderStatus == BlobLoaderStarted);
 }
 
 void WebSocketChannel::didReceiveData()
 {
-    D(kprintf("WebSocketChannel %p didReceiveData()\n", this));
+    D(bug("WebSocketChannel %p didReceiveData()\n", this));
     ASSERT(m_blobLoader);
     ASSERT(m_blobLoaderStatus == BlobLoaderStarted);
 }
 
 void WebSocketChannel::didFinishLoading()
 {
-    D(kprintf("WebSocketChannel %p didFinishLoading()\n", this));
+    D(bug("WebSocketChannel %p didFinishLoading()\n", this));
     ASSERT(m_blobLoader);
     ASSERT(m_blobLoaderStatus == BlobLoaderStarted);
     m_blobLoaderStatus = BlobLoaderFinished;
@@ -397,7 +400,7 @@ void WebSocketChannel::didFinishLoading()
 
 void WebSocketChannel::didFail(int errorCode)
 {
-    D(kprintf("WebSocketChannel %p didFail() errorCode=%d\n", this, errorCode));
+    D(bug("WebSocketChannel %p didFail() errorCode=%d\n", this, errorCode));
     ASSERT(m_blobLoader);
     ASSERT(m_blobLoaderStatus == BlobLoaderStarted);
     m_blobLoader.clear();
@@ -411,7 +414,7 @@ bool WebSocketChannel::appendToBuffer(const char* data, size_t len)
 {
     size_t newBufferSize = m_buffer.size() + len;
     if (newBufferSize < m_buffer.size()) {
-        D(kprintf("WebSocketChannel %p appendToBuffer() Buffer overflow (%lu bytes already in receive buffer and appending %lu bytes)\n", this, static_cast<unsigned long>(m_buffer.size()), static_cast<unsigned long>(len)));
+        D(bug("WebSocketChannel %p appendToBuffer() Buffer overflow (%lu bytes already in receive buffer and appending %lu bytes)\n", this, static_cast<unsigned long>(m_buffer.size()), static_cast<unsigned long>(len)));
         return false;
     }
     m_buffer.append(data, len);
@@ -430,7 +433,7 @@ bool WebSocketChannel::processBuffer()
     ASSERT(!m_suspended);
     ASSERT(m_client);
     ASSERT(!m_buffer.isEmpty());
-    D(kprintf("WebSocketChannel %p processBuffer() Receive buffer has %lu bytes\n", this, static_cast<unsigned long>(m_buffer.size())));
+    D(bug("WebSocketChannel %p processBuffer() Receive buffer has %lu bytes\n", this, static_cast<unsigned long>(m_buffer.size())));
 
     if (m_shouldDiscardReceivedData)
         return false;
@@ -456,14 +459,14 @@ bool WebSocketChannel::processBuffer()
                 }
             }
             // FIXME: handle set-cookie2.
-            D(kprintf("WebSocketChannel %p Connected\n", this));
+            D(bug("WebSocketChannel %p Connected\n", this));
             skipBuffer(headerLength);
             m_client->didConnect();
-            D(kprintf("WebSocketChannel %p %lu bytes remaining in m_buffer\n", this, static_cast<unsigned long>(m_buffer.size())));
+            D(bug("WebSocketChannel %p %lu bytes remaining in m_buffer\n", this, static_cast<unsigned long>(m_buffer.size())));
             return !m_buffer.isEmpty();
         }
         ASSERT(m_handshake->mode() == WebSocketHandshake::Failed);
-        D(kprintf("WebSocketChannel %p Connection failed\n", this));
+        D(bug("WebSocketChannel %p Connection failed\n", this));
         skipBuffer(headerLength);
         m_shouldDiscardReceivedData = true;
         fail(m_handshake->failureReason());
@@ -489,7 +492,7 @@ void WebSocketChannel::resumeTimerFired(Timer<WebSocketChannel>* timer)
 
 void WebSocketChannel::startClosingHandshake(int code, const String& reason)
 {
-    D(kprintf("WebSocketChannel %p startClosingHandshake() code=%d m_receivedClosingHandshake=%d\n", this, m_closing, m_receivedClosingHandshake));
+    D(bug("WebSocketChannel %p startClosingHandshake() code=%d m_receivedClosingHandshake=%d\n", this, m_closing, m_receivedClosingHandshake));
     if (m_closing)
         return;
     ASSERT(m_handle);
@@ -512,7 +515,7 @@ void WebSocketChannel::startClosingHandshake(int code, const String& reason)
 
 void WebSocketChannel::closingTimerFired(Timer<WebSocketChannel>* timer)
 {
-    D(kprintf("WebSocketChannel %p closingTimerFired()\n", this));
+    D(bug("WebSocketChannel %p closingTimerFired()\n", this));
     ASSERT_UNUSED(timer, &m_closingTimer == timer);
     if (m_handle)
         m_handle->disconnect();

--- a/odyssey-r155188-1.23/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
+++ b/odyssey-r155188-1.23/Source/WebCore/Modules/websockets/WebSocketDeflater.cpp
@@ -30,9 +30,12 @@
 
 #include "config.h"
 
-#include <proto/exec.h>
-#define kprintf IExec->DebugPrintF 
-#define D(x) //#define D(x) x  to enalbed debug 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 #include "WebSocketDeflater.h"
 
@@ -76,7 +79,7 @@ WebSocketDeflater::~WebSocketDeflater()
 {
     int result = deflateEnd(m_stream.get());
     if (result != Z_OK)
-        D(kprintf("WebSocketDeflater %p Destructor deflateEnd() failed: %d is returned\n", this, result));
+        D(bug("WebSocketDeflater %p Destructor deflateEnd() failed: %d is returned\n", this, result));
 }
 
 static void setStreamParameter(z_stream* stream, const char* inputData, size_t inputLength, char* outputData, size_t outputLength)
@@ -153,7 +156,7 @@ WebSocketInflater::~WebSocketInflater()
 {
     int result = inflateEnd(m_stream.get());
     if (result != Z_OK)
-        D(kprintf("WebSocketInflater %p Destructor inflateEnd() failed: %d is returned\n", this, result));
+        D(bug("WebSocketInflater %p Destructor inflateEnd() failed: %d is returned\n", this, result));
 }
 
 bool WebSocketInflater::addBytes(const char* data, size_t length)

--- a/odyssey-r155188-1.23/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
+++ b/odyssey-r155188-1.23/Source/WebCore/Modules/websockets/WebSocketHandshake.cpp
@@ -31,9 +31,12 @@
 
 #include "config.h"
 
-#include <proto/exec.h>
-#define kprintf IExec->DebugPrintF 
-#define D(x) //#define D(x) x  to enalbed debug 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 #if ENABLE(WEB_SOCKETS)
 
@@ -302,7 +305,7 @@ int WebSocketHandshake::readServerHandshake(const char* header, size_t len)
         m_mode = Failed; // m_failureReason is set inside readStatusLine().
         return len;
     }
-    D(kprintf("WebSocketHandshake %p readServerHandshake() Status code is %d\n", this, statusCode));
+    D(bug("WebSocketHandshake %p readServerHandshake() Status code is %d\n", this, statusCode));
 
     m_serverHandshakeResponse = ResourceResponse();
     m_serverHandshakeResponse.setHTTPStatusCode(statusCode);
@@ -321,12 +324,12 @@ int WebSocketHandshake::readServerHandshake(const char* header, size_t len)
     }
     const char* p = readHTTPHeaders(header + lineLength, header + len);
     if (!p) {
-        D(kprintf("WebSocketHandshake %p readServerHandshake() readHTTPHeaders() failed\n", this));
+        D(bug("WebSocketHandshake %p readServerHandshake() readHTTPHeaders() failed\n", this));
         m_mode = Failed; // m_failureReason is set inside readHTTPHeaders().
         return len;
     }
     if (!checkResponseHeaders()) {
-        D(kprintf("WebSocketHandshake %p readServerHandshake() checkResponseHeaders() failed\n", this));
+        D(bug("WebSocketHandshake %p readServerHandshake() checkResponseHeaders() failed\n", this));
         m_mode = Failed;
         return p - header;
     }

--- a/odyssey-r155188-1.23/Source/WebCore/bridge/bal/BalInstance.cpp
+++ b/odyssey-r155188-1.23/Source/WebCore/bridge/bal/BalInstance.cpp
@@ -47,7 +47,12 @@
 #include "runtime_method.h"
 #include "runtime_object.h"
 
-#include <clib/debug_protos.h>
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 using namespace WebCore;
 
@@ -276,7 +281,7 @@ void BalInstance::getPropertyNames(ExecState* exec, PropertyNameArray& nameArray
 
 RuntimeObject* BalInstance::newRuntimeObject(ExecState* exec)
 {
-    kprintf("BalInstance::newRuntimeObject\n");
+    D(bug("BalInstance::newRuntimeObject\n"));
     //JSLock lock(exec);
     RuntimeObject* object = static_cast<RuntimeObject*>(cachedObjects.get(this));
     if (!object) {

--- a/odyssey-r155188-1.23/Source/WebCore/inspector/InspectorFrontendHost.cpp
+++ b/odyssey-r155188-1.23/Source/WebCore/inspector/InspectorFrontendHost.cpp
@@ -28,7 +28,6 @@
  */
 
 #include "config.h"
-#include <clib/debug_protos.h>
 
 #if ENABLE(INSPECTOR)
 

--- a/odyssey-r155188-1.23/Source/WebCore/loader/AdBlock.cpp
+++ b/odyssey-r155188-1.23/Source/WebCore/loader/AdBlock.cpp
@@ -34,7 +34,6 @@
 #include <wtf/Vector.h>
 
 #include <stdio.h>
-#include <clib/debug_protos.h>
 #include "../../WebKit/OrigynWebBrowser/Api/MorphOS/gui.h"
 
 namespace WebCore {

--- a/odyssey-r155188-1.23/Source/WebCore/page/DragController.cpp
+++ b/odyssey-r155188-1.23/Source/WebCore/page/DragController.cpp
@@ -81,8 +81,6 @@
 #include <wtf/CurrentTime.h>
 #include <wtf/RefPtr.h>
 
-#include <clib/debug_protos.h>
-
 namespace WebCore {
 
 static PlatformMouseEvent createMouseEvent(DragData* dragData)

--- a/odyssey-r155188-1.23/Source/WebCore/plugins/MorphOS/PluginPackageMorphOS.cpp
+++ b/odyssey-r155188-1.23/Source/WebCore/plugins/MorphOS/PluginPackageMorphOS.cpp
@@ -33,8 +33,12 @@
 #include "npruntime_impl.h"
 #include "PluginDebug.h"
 #include "../../../WebKit/OrigynWebBrowser/Api/MorphOS/gui.h"
-#include <clib/debug_protos.h>
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 #define MIN_PLUGIN_VERSION 2
@@ -110,7 +114,7 @@ bool PluginPackage::fetchInfo()
 
 		//determineQuirks(mimeData[0]);
 
-		D(kprintf("PluginPackage: Adding mimetype: %s|%s|%s\n", mimeData[0].latin1().data(), extensions[0].latin1().data(), description.latin1().data()));
+		D(bug("PluginPackage: Adding mimetype: %s|%s|%s\n", mimeData[0].latin1().data(), extensions[0].latin1().data(), description.latin1().data()));
 
 		m_mimeToExtensions.add(mimeData[0], extensions);
         m_mimeToDescriptions.add(mimeData[0], description);
@@ -130,7 +134,7 @@ bool PluginPackage::load()
 
 	stccpy(cmodule, m_path.latin1().data(), sizeof(cmodule));
 
-	D(kprintf("PluginPackage: OpenLibrary(%s)\n", cmodule));
+	D(bug("PluginPackage: OpenLibrary(%s)\n", cmodule));
 
 	m_module = (struct Library *) OpenLibrary(cmodule, MIN_PLUGIN_VERSION);
 
@@ -159,7 +163,7 @@ bool PluginPackage::load()
 	}
 	else
 	{
-		D(kprintf("PluginPackageLoading: Opening %s failed\n", cmodule));
+		D(bug("PluginPackageLoading: Opening %s failed\n", cmodule));
 		return false;
 	}
 

--- a/odyssey-r155188-1.23/Source/WebCore/plugins/MorphOS/PluginViewMorphOS.cpp
+++ b/odyssey-r155188-1.23/Source/WebCore/plugins/MorphOS/PluginViewMorphOS.cpp
@@ -62,7 +62,13 @@
 #include <fcntl.h>
 //#include <sys/mman.h>
 
-#include <clib/debug_protos.h>
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
 
 using JSC::ExecState;
 using JSC::Interpreter;
@@ -91,7 +97,7 @@ void PluginView::updatePluginWidget()
     m_clipRect = windowClipRect();
     m_clipRect.move(-m_windowRect.x(), -m_windowRect.y());
 
-	//kprintf("PluginView::updatePluginWidget %p [%d %d %d %d]\n", platformPluginWidget(), m_windowRect.x(), m_windowRect.y(), m_windowRect.width(), m_windowRect.height());
+	//D(bug("PluginView::updatePluginWidget %p [%d %d %d %d]\n", platformPluginWidget(), m_windowRect.x(), m_windowRect.y(), m_windowRect.width(), m_windowRect.height()));
 
     if (platformPluginWidget() && (m_windowRect != oldWindowRect || m_clipRect != oldClipRect))
 		setNPWindowRect(m_windowRect);
@@ -204,7 +210,7 @@ void PluginView::setNPWindowRect(const IntRect& rect)
         return;
 	*/
 
-	//kprintf("PluginView::setNPWindowRect(%d %d %d %d)\n", m_npWindow.x, m_npWindow.y, m_npWindow.width, m_npWindow.height);
+	//D(bug("PluginView::setNPWindowRect(%d %d %d %d)\n", m_npWindow.x, m_npWindow.y, m_npWindow.width, m_npWindow.height));
 
     PluginView::setCurrentPluginView(this);
     JSC::JSLock::DropAllLocks dropAllLocks(JSDOMWindowBase::commonVM());
@@ -290,12 +296,12 @@ bool PluginView::platformGetValue(NPNVariable variable, void* value, NPError* re
 
 void PluginView::invalidateRegion(NPRegion)
 {
-	//kprintf("PluginView::invalidateRegion\n");
+	//D(bug("PluginView::invalidateRegion\n"));
 }
 
 void PluginView::invalidateRect(NPRect* rect)
 {
-	//kprintf("PluginView::invalidateRect [%d %d %d %d]\n", rect->left, rect->top, rect->right - rect->left, rect->bottom - rect->top);
+	//D(bug("PluginView::invalidateRect [%d %d %d %d]\n", rect->left, rect->top, rect->right - rect->left, rect->bottom - rect->top));
 
     if (!rect) {
         invalidate();
@@ -308,13 +314,13 @@ void PluginView::invalidateRect(NPRect* rect)
 
 void PluginView::invalidateRect(const IntRect& rect)
 {
-	//kprintf("PluginView::invalidateRect2 [%d %d %d %d]\n", rect.x(), rect.y(), rect.width(), rect.height());
+	//D(bug("PluginView::invalidateRect2 [%d %d %d %d]\n", rect.x(), rect.y(), rect.width(), rect.height()));
 	Widget::invalidateRect(rect);
 }
 
 void PluginView::forceRedraw()
 {
-	//kprintf("PluginView::forceRedraw\n");
+	//D(bug("PluginView::forceRedraw\n"));
 	invalidate();
 }
 
@@ -336,7 +342,7 @@ bool PluginView::platformStart()
 
 	setPlatformPluginWidget(m_parentFrame.get()->view()->hostWindow()->platformPageClient());
 
-	//kprintf("platformStart() widget %p\n", m_parentFrame.get()->view()->hostWindow()->platformPageClient());
+	//D(bug("platformStart() widget %p\n", m_parentFrame.get()->view()->hostWindow()->platformPageClient()));
 
     show();
 

--- a/odyssey-r155188-1.23/Source/WebCore/plugins/PluginPackage.cpp
+++ b/odyssey-r155188-1.23/Source/WebCore/plugins/PluginPackage.cpp
@@ -37,8 +37,6 @@
 #include <wtf/OwnArrayPtr.h>
 #include <wtf/text/CString.h>
 
-#include <clib/debug_protos.h>
-
 namespace WebCore {
 
 PluginPackage::~PluginPackage()

--- a/odyssey-r155188-1.23/Source/WebCore/plugins/PluginStream.cpp
+++ b/odyssey-r155188-1.23/Source/WebCore/plugins/PluginStream.cpp
@@ -39,7 +39,12 @@
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/WTFString.h>
 
-#include <clib/debug_protos.h>
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 // We use -2 here because some plugins like to return -1 to indicate error
 // and this way we won't clash with them.
@@ -230,7 +235,7 @@ void PluginStream::cancelAndDestroyStream(NPReason reason)
 
     if(!this)
       {
-	kprintf("PluginStream::destroyStream() this == NULL, it hurts!\n");
+	D(bug("PluginStream::destroyStream() this == NULL, it hurts!\n"));
 	return;
       }  
 
@@ -315,7 +320,7 @@ void PluginStream::destroyStream()
             m_stream.url = 0;
         }
 
-		//kprintf("PluginStream::destroyStream invoking urlnotify %p\n", m_pluginFuncs->urlnotify);
+		//D(bug("PluginStream::destroyStream invoking urlnotify %p\n", m_pluginFuncs->urlnotify));
 		//m_pluginFuncs->urlnotify(m_instance, m_resourceRequest.url().string().utf8().data(), m_reason, m_notifyData);
         if (m_loader)
             m_loader->setDefersLoading(false);

--- a/odyssey-r155188-1.23/Source/WebCore/rendering/RenderTheme.cpp
+++ b/odyssey-r155188-1.23/Source/WebCore/rendering/RenderTheme.cpp
@@ -442,7 +442,6 @@ bool RenderTheme::paintBorderOnly(RenderObject* o, const PaintInfo& paintInfo, c
     return false;
 }
 
-#include <clib/debug_protos.h>
 bool RenderTheme::paintDecorations(RenderObject* o, const PaintInfo& paintInfo, const IntRect& r)
 {
     if (paintInfo.context->paintingDisabled())

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/DefaultPolicyDelegate.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/DefaultPolicyDelegate.cpp
@@ -56,7 +56,6 @@
 #include "utils.h"
 #include <proto/dos.h>
 #include <proto/intuition.h>
-#include <clib/debug_protos.h>
 #undef get
 #undef String
 #undef Read

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/AutofillManager.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/AutofillManager.cpp
@@ -26,7 +26,6 @@
 #include "HTMLInputElement.h"
 
 #include "gui.h"
-#include <clib/debug_protos.h>
 
 namespace WebCore {
 

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/DownloadDelegateMorphOS.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/DownloadDelegateMorphOS.cpp
@@ -43,7 +43,6 @@
 #include <proto/dos.h>
 #include <dos/dostags.h>
 #include <proto/utility.h>
-#include <clib/debug_protos.h>
 
 #include <stdio.h>
 
@@ -53,7 +52,13 @@
 
 #undef set
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
+
 
 using namespace WebCore;
 
@@ -63,12 +68,12 @@ DownloadDelegateMorphOS::DownloadDelegateMorphOS()
 
 DownloadDelegateMorphOS::~DownloadDelegateMorphOS()
 {
-	D(kprintf("DownloadDelegateMorphOS::~DownloadDelegateMorphOS\n"));
+	D(bug("DownloadDelegateMorphOS::~DownloadDelegateMorphOS\n"));
 }
 
 void DownloadDelegateMorphOS::decideDestinationWithSuggestedFilename(WebDownload *download, const char* fileName)
 {
-	D(kprintf("DownloadDelegateMorphOS::decideDestinationWithSuggestedFilename(%s)\n", fileName));
+	D(bug("DownloadDelegateMorphOS::decideDestinationWithSuggestedFilename(%s)\n", fileName));
 
     if(fileName)
     {
@@ -164,7 +169,7 @@ void DownloadDelegateMorphOS::decideDestinationWithSuggestedFilename(WebDownload
 						}
 					}
 
-					D(kprintf("destination %s overwrite %d resume %d\n", localUri, overwrite, resume));
+					D(bug("destination %s overwrite %d resume %d\n", localUri, overwrite, resume));
 
 					download->setDestination(localUri, overwrite, resume);
 
@@ -177,22 +182,22 @@ void DownloadDelegateMorphOS::decideDestinationWithSuggestedFilename(WebDownload
 
 void DownloadDelegateMorphOS::didCancelAuthenticationChallenge(WebDownload* download, WebURLAuthenticationChallenge* challenge)
 {
-    D(kprintf("DownloadDelegateMorphOS %p - didCancelAuthenticationChallenge %p\n", download, challenge));
+    D(bug("DownloadDelegateMorphOS %p - didCancelAuthenticationChallenge %p\n", download, challenge));
 }
 
 void DownloadDelegateMorphOS::didCreateDestination(WebDownload* download, const char *destination)
 {
-    D(kprintf("DownloadDelegateMorphOS %p - didCreateDestination %s\n", download, destination));
+    D(bug("DownloadDelegateMorphOS %p - didCreateDestination %s\n", download, destination));
 }
 
 void DownloadDelegateMorphOS::didReceiveAuthenticationChallenge(WebDownload* download, WebURLAuthenticationChallenge* challenge)
 {
-    D(kprintf("DownloadDelegateMorphOS %p - didReceiveAuthenticationChallenge %p\n", download, challenge));
+    D(bug("DownloadDelegateMorphOS %p - didReceiveAuthenticationChallenge %p\n", download, challenge));
 }
 
 void DownloadDelegateMorphOS::didReceiveDataOfLength(WebDownload* download, unsigned length)
 {
-    D(kprintf("DownloadDelegateMorphOS %p - didReceiveDataOfLength %p %d\n", download, length));
+    D(bug("DownloadDelegateMorphOS %p - didReceiveDataOfLength %p %d\n", download, length));
 
 	WebDownloadPrivate* priv = download->getWebDownloadPrivate();
 
@@ -212,7 +217,7 @@ void DownloadDelegateMorphOS::didReceiveDataOfLength(WebDownload* download, unsi
 
 void DownloadDelegateMorphOS::didReceiveResponse(WebDownload* download, WebURLResponse* response)
 {
-    D(kprintf("DownloadDelegateMorphOS %p - didReceiveResponse %p\n", download, response));
+    D(bug("DownloadDelegateMorphOS %p - didReceiveResponse %p\n", download, response));
 
 	WebDownloadPrivate* priv = download->getWebDownloadPrivate();
 
@@ -222,12 +227,12 @@ void DownloadDelegateMorphOS::didReceiveResponse(WebDownload* download, WebURLRe
 
 void DownloadDelegateMorphOS::willResumeWithResponse(WebDownload* download, WebURLResponse* response, long long fromByte)
 {
-    D(kprintf("DownloadDelegateMorphOS %p - willResumeWithResponse %p, %q\n", download, response, fromByte));
+    D(bug("DownloadDelegateMorphOS %p - willResumeWithResponse %p, %q\n", download, response, fromByte));
 }
 
 WebMutableURLRequest* DownloadDelegateMorphOS::willSendRequest(WebDownload* download, WebMutableURLRequest* request, WebURLResponse* redirectResponse)
 {
-    D(kprintf("DownloadDelegateMorphOS %p - willSendRequest %p %p\n", download, request, redirectResponse));
+    D(bug("DownloadDelegateMorphOS %p - willSendRequest %p %p\n", download, request, redirectResponse));
     return request;
 }
 
@@ -238,7 +243,7 @@ bool DownloadDelegateMorphOS::shouldDecodeSourceDataOfMIMEType(WebDownload*, con
 
 void DownloadDelegateMorphOS::didBegin(WebDownload* download)
 {
-    D(kprintf("DownloadDelegateMorphOS %p - didBegin\n", download));
+    D(bug("DownloadDelegateMorphOS %p - didBegin\n", download));
     registerDownload(download);
 	
 	DoMethod(app, MM_OWBApp_OpenWindow, MV_OWB_Window_Downloads, FALSE);
@@ -250,7 +255,7 @@ void DownloadDelegateMorphOS::didBegin(WebDownload* download)
 
 void DownloadDelegateMorphOS::didFinish(WebDownload* download)
 {
-    D(kprintf("DownloadDelegateMorphOS %p - didFinish\n", download));
+    D(bug("DownloadDelegateMorphOS %p - didFinish\n", download));
 
 	WebDownloadPrivate* priv = download->getWebDownloadPrivate();
 	char cpath[1024];
@@ -269,13 +274,13 @@ void DownloadDelegateMorphOS::didFinish(WebDownload* download)
 
 	DoMethod(app, MM_OWBApp_DownloadDone, priv->dl);
 
-	D(kprintf("DownloadDelegateMorphOS %p - SetComment(%s, %s)\n", download, (STRPTR) priv->destinationPath.latin1().data(), (STRPTR) priv->requestUri.utf8().data()));
+	D(bug("DownloadDelegateMorphOS %p - SetComment(%s, %s)\n", download, (STRPTR) priv->destinationPath.latin1().data(), (STRPTR) priv->requestUri.utf8().data()));
 
 	SetComment((STRPTR) cpath, (STRPTR) ccomment);
 
 	if(!priv->command.isEmpty())
 	{
-		D(kprintf("Check DownloadDelegateMorphOS %p - Command (%s)\n", download, (STRPTR) priv->command.latin1().data()));
+		D(bug("Check DownloadDelegateMorphOS %p - Command (%s)\n", download, (STRPTR) priv->command.latin1().data()));
 
 		OWBCommand cmd(priv->command, ACTION_AMIGADOS);
 		cmd.execute();
@@ -289,7 +294,7 @@ void DownloadDelegateMorphOS::didFailWithError(WebDownload* download, WebError* 
 {
 	char *errormsg = (char *) error->localizedDescription();
 
-	D(kprintf("DownloadDelegateMorphOS %p - didFailWithError(%s)\n", download, errormsg));
+	D(bug("DownloadDelegateMorphOS %p - didFailWithError(%s)\n", download, errormsg));
 
 	WebDownloadPrivate* priv = download->getWebDownloadPrivate();
 

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/OWBPrintContext.h
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/OWBPrintContext.h
@@ -35,8 +35,6 @@
 #include "FrameView.h"
 #include "PrintContext.h"
 
-#include <clib/debug_protos.h>
-
 namespace WebCore {
 
 // Simple class to override some of PrintContext behavior.
@@ -77,7 +75,6 @@ public:
 	virtual float spoolPage(GraphicsContext& ctx, int pageNumber, float scale = 1.0)
     {
         IntRect pageRect = m_pageRects[pageNumber];
-		//kprintf("spoolPage %d pageRect [%d %d %d %d] m_printedPageWidth %f scale %f\n", pageNumber, pageRect.x(), pageRect.y(), pageRect.width(), pageRect.height(), m_printedPageWidth, scale);
 
         ctx.save();
 #if OS(MORPHOS) && !OS(DARWIN)

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/TopSitesManager.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/TopSitesManager.cpp
@@ -38,7 +38,13 @@
 #include "WTFString.h"
 
 #include "gui.h"
-#include <clib/debug_protos.h>
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 /*
 
@@ -374,8 +380,8 @@ int TopSitesManager::requiredVisitCount()
 		minVisitCount = select.getColumnInt(0);
 	}	
 	
-	//kprintf("requiredVisitCount %d\n", minVisitCount);
-	//kprintf("entries < maxEntries %d\n",entries() < maxEntries());
+	//D(bug("requiredVisitCount %d\n", minVisitCount));
+	//D(bug("entries < maxEntries %d\n",entries() < maxEntries()));
 	
 	return (entries() < maxEntries()) ? 1 : minVisitCount;
 }
@@ -393,7 +399,7 @@ void TopSitesManager::update(WebView *webView, KURL &url, String &title)
 			String query = url.string().substring(index + 1);
 			if(!query.isEmpty())
 			{
-				//kprintf("query : <%s>\n", query.utf8().data());
+				//D(bug("query : <%s>\n", query.utf8().data()));
 
 				if(query.startsWith("remove="))
 				{
@@ -484,7 +490,7 @@ bool TopSitesManager::addOrUpdate(WebView *webView, KURL &url, String &title)
 	Vector<char> screenshot;
 	bool found = false;
 
-	//kprintf("addOrUpdate <%s>\n", url.string().utf8().data());
+	//D(bug("addOrUpdate <%s>\n", url.string().utf8().data()));
 
 	SQLiteStatement select(m_topSitesDB, "SELECT visitCount, screenshot, lastAccessed FROM topsites WHERE url=?1;");
 	if(select.prepare())
@@ -500,7 +506,7 @@ bool TopSitesManager::addOrUpdate(WebView *webView, KURL &url, String &title)
 		lastAccessed = select.getColumnDouble(2);		
 	}	
 
-	//kprintf("visitCount %d required : %d screenshot %d timestamp %f lastaccessed %d\n", visitCount, requiredVisitCount(), screenshot.size(), timestamp, lastAccessed);
+	//D(bug("visitCount %d required : %d screenshot %d timestamp %f lastaccessed %d\n", visitCount, requiredVisitCount(), screenshot.size(), timestamp, lastAccessed));
 	bool generateScreenshot = !m_disableScreenShots && (visitCount >= requiredVisitCount()) && (screenshot.size() == 0 || (timestamp >= lastAccessed + SCREENSHOT_UPDATE_DELAY));
 
 	if(found)
@@ -543,7 +549,7 @@ bool TopSitesManager::addOrUpdate(WebView *webView, KURL &url, String &title)
 		int height;
 		Vector<char> imageData;
 
-		//kprintf("Generate screenshot for <%s>\n", url.string().utf8().data());
+		//D(bug("Generate screenshot for <%s>\n", url.string().utf8().data()));
 		webView->screenshot(width, height, &imageData);
 		
 		SQLiteStatement updateScreenShotStmt(m_topSitesDB, "UPDATE topsites SET screenshot=?1 WHERE url=?2;");

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/WebViewPrivate.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/WebViewPrivate.cpp
@@ -89,7 +89,6 @@
 #include "gui.h"
 #include "utils.h"
 #include "asl.h"
-#include <clib/debug_protos.h>
 #include <proto/dos.h>
 #include <proto/graphics.h>
 #include <proto/intuition.h>
@@ -99,6 +98,11 @@
 #include <devices/rawkeycodes.h>
 #include <devices/inputevent.h>
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 #undef PageGroup
@@ -236,29 +240,29 @@ MorphOSJSActionDelegate::~MorphOSJSActionDelegate()
 
 void MorphOSWebFrameDelegate::windowObjectClearNotification(WebFrame*, void*, void*)
 {
-	D(kprintf("windowObjectClearNotification\n"));
+	D(bug("windowObjectClearNotification\n"));
 }
 
 void MorphOSWebFrameDelegate::didReceiveServerRedirectForProvisionalLoadForFrame(WebFrame*)
 {
-	D(kprintf("didReceiveServerRedirectForProvisionalLoadForFrame\n"));
+	D(bug("didReceiveServerRedirectForProvisionalLoadForFrame\n"));
 }
 
 void MorphOSWebFrameDelegate::didCancelClientRedirectForFrame(WebFrame*)
 {
-	D(kprintf("didCancelClientRedirectForFrame\n"));
+	D(bug("didCancelClientRedirectForFrame\n"));
 }
 
 void MorphOSWebFrameDelegate::willPerformClientRedirectToURL(WebFrame*, const char*, double, double)
 {
-	D(kprintf("willPerformClientRedirectToURL\n"));
+	D(bug("willPerformClientRedirectToURL\n"));
 }
 
 void MorphOSWebFrameDelegate::didStartProvisionalLoad(WebFrame* webFrame)
 {
     WebView* webView = webFrame->webView();
 
-	D(kprintf("didStartProvisionalLoad\n"));
+	D(bug("didStartProvisionalLoad\n"));
 
     if (webView->mainFrame() != webFrame)
         return;
@@ -302,7 +306,7 @@ void MorphOSWebFrameDelegate::didCommitLoad(WebFrame* webFrame)
 {
     WebView* webView = webFrame->webView();
 
-	D(kprintf("didCommitLoad\n"));
+	D(bug("didCommitLoad\n"));
 
     if (webView->mainFrame() != webFrame)
         return;
@@ -338,7 +342,7 @@ void MorphOSWebFrameDelegate::didFinishLoad(WebFrame* webFrame)
 	BalWidget* widget = webView->viewWindow();
     WebFrame* mainFrame = webView->mainFrame();
 
-	D(kprintf("didFinishLoad\n"));
+	D(bug("didFinishLoad\n"));
 
     if (mainFrame != webFrame)
         return;
@@ -395,7 +399,7 @@ void MorphOSWebFrameDelegate::didFinishLoad(WebFrame* webFrame)
 
 void MorphOSWebFrameDelegate::didFailProvisionalLoad(WebFrame* webFrame, WebError* error)
 {
-	D(kprintf("didFailProvisionalLoad\n"));
+	D(bug("didFailProvisionalLoad\n"));
 
 	didFailLoad(webFrame, error);
 }
@@ -408,7 +412,7 @@ void MorphOSWebFrameDelegate::didFailLoad(WebFrame* webFrame, WebError* error)
     // XXX: Is it right to filter it that way?
     bool handleAsError = !error->resourceError().isCancellation() && !error->isPolicyChangeError() && error->code() != 204 /*&& error->code() != 23*/;
 
-    D(kprintf("didFailLoad code %d frame %p mainframe %p\n", error->code(), webFrame, mainFrame));
+    D(bug("didFailLoad code %d frame %p mainframe %p\n", error->code(), webFrame, mainFrame));
 
     if (mainFrame != webFrame)
         return;
@@ -425,7 +429,7 @@ void MorphOSWebFrameDelegate::didFailLoad(WebFrame* webFrame, WebError* error)
 
 	if(error->resourceError().sslErrors())
 	{
-		//kprintf("SSL Error %d\n", error->resourceError().sslErrors());
+		//D(bug("SSL Error %d\n", error->resourceError().sslErrors()));
 	}
 
 	if(handleAsError)
@@ -471,7 +475,7 @@ void MorphOSWebFrameDelegate::didFinishDocumentLoadForFrame(WebFrame* webFrame)
 {
 	WebView* webView = webFrame->webView();
 	
-	D(kprintf("didFinishDocumentLoadForFrame\n"));
+	D(bug("didFinishDocumentLoadForFrame\n"));
 
 	BalWidget* widget = webView->viewWindow();
 
@@ -485,7 +489,7 @@ void MorphOSWebFrameDelegate::willCloseFrame(WebFrame* webFrame)
 {
 	WebView* webView = webFrame->webView();
 	
-	D(kprintf("willCloseFrame\n"));
+	D(bug("willCloseFrame\n"));
 
 	BalWidget* widget = webView->viewWindow();
 
@@ -497,29 +501,29 @@ void MorphOSWebFrameDelegate::willCloseFrame(WebFrame* webFrame)
 
 void MorphOSWebFrameDelegate::didHandleOnloadEventsForFrame(WebFrame*)
 {
-	D(kprintf("didHandleOnloadEventsForFrame\n"));
+	D(bug("didHandleOnloadEventsForFrame\n"));
 }
 
 void MorphOSWebFrameDelegate::didChangeLocationWithinPageForFrame(WebFrame*)
 {
-	D(kprintf("didChangeLocationWithinPageForFrame\n"));
+	D(bug("didChangeLocationWithinPageForFrame\n"));
 }
 
 void MorphOSWebFrameDelegate::didFirstLayoutInFrame(WebFrame*)
 {
-	D(kprintf("dispatchDidFirstLayout\n"));
+	D(bug("dispatchDidFirstLayout\n"));
 }
 
 void MorphOSWebFrameDelegate::didFirstVisuallyNonEmptyLayoutInFrame(WebFrame*)
 {
-	D(kprintf("dispatchDidFirstVisuallyNonEmptyLayout\n"));
+	D(bug("dispatchDidFirstVisuallyNonEmptyLayout\n"));
 }
 
 void MorphOSWebFrameDelegate::titleChange(WebFrame* webFrame, const char* title)
 {
 	WebView* webView = webFrame->webView();
 
-	D(kprintf("titleChange\n"));
+	D(bug("titleChange\n"));
 	
 	if (webView->mainFrame() != webFrame)
         return;
@@ -533,14 +537,14 @@ void MorphOSWebFrameDelegate::titleChange(WebFrame* webFrame, const char* title)
 
 void MorphOSWebFrameDelegate::dispatchNotEnoughMemory(WebFrame*)
 {
-	kprintf("dispatchNotEnoughMemory\n");
+	D(bug("dispatchNotEnoughMemory\n"));
 }
 
 void MorphOSWebFrameDelegate::didDisplayInsecureContent(WebFrame* webFrame)
 {
     WebView* webView = webFrame->webView();
 
-	D(kprintf("didDisplayInsecureContent\n"));
+	D(bug("didDisplayInsecureContent\n"));
 
     if (webView->mainFrame() != webFrame)
         return;
@@ -559,7 +563,7 @@ void MorphOSWebFrameDelegate::didRunInsecureContent(WebFrame* webFrame, WebSecur
 {
     WebView* webView = webFrame->webView();
 
-	D(kprintf("didRunInsecureContent\n"));
+	D(bug("didRunInsecureContent\n"));
 
     if (webView->mainFrame() != webFrame)
         return;
@@ -576,7 +580,7 @@ void MorphOSWebFrameDelegate::didRunInsecureContent(WebFrame* webFrame, WebSecur
 
 void MorphOSWebFrameDelegate::didChangeIcons(WebFrame* webFrame)
 {
-	D(kprintf("didChangeIcons\n"));
+	D(bug("didChangeIcons\n"));
 }
 
 void MorphOSWebFrameDelegate::updateURL(void *browser, char *url)
@@ -643,49 +647,49 @@ MorphOSResourceLoadDelegate::~MorphOSResourceLoadDelegate()
 void MorphOSResourceLoadDelegate::identifierForInitialRequest(WebView* webView, WebMutableURLRequest* request, WebDataSource* dataSource, unsigned long identifier)
 {
 	const char *url = request->URL();
-	kprintf("MorphOSResourceLoadDelegate::identifierForInitialRequest [%d - %s ]\n", identifier, url);
+	D(bug("MorphOSResourceLoadDelegate::identifierForInitialRequest [%d - %s ]\n", identifier, url));
 	free((char *)url);
 }
 
 WebMutableURLRequest* MorphOSResourceLoadDelegate::willSendRequest(WebView* webView, unsigned long identifier, WebMutableURLRequest* request, WebURLResponse* redirectResponse, WebDataSource* dataSource)
 {
-	kprintf("MorphOSResourceLoadDelegate::willSendRequest(%d)\n", identifier);
+	D(bug("MorphOSResourceLoadDelegate::willSendRequest(%d)\n", identifier));
     return request;
 }
 
 void MorphOSResourceLoadDelegate::didFinishLoadingFromDataSource(WebView* webView, unsigned long identifier, WebDataSource* dataSource)
 {
-	kprintf("MorphOSResourceLoadDelegate::didFinishLoadingFromDataSource(%d)\n", identifier);
+	D(bug("MorphOSResourceLoadDelegate::didFinishLoadingFromDataSource(%d)\n", identifier));
 }
 
 void MorphOSResourceLoadDelegate::didFailLoadingWithError(WebView* webView, unsigned long identifier, WebError* error, WebDataSource* dataSource)
 {
-	kprintf("MorphOSResourceLoadDelegate::didFailLoadingWithError(%d)\n", identifier);
+	D(bug("MorphOSResourceLoadDelegate::didFailLoadingWithError(%d)\n", identifier));
 }
 
 void MorphOSResourceLoadDelegate::didReceiveResponse(WebView *webView, unsigned long identifier, WebURLResponse *response, WebDataSource *dataSource)
 {
-	kprintf("MorphOSResourceLoadDelegate::didReceiveResponse(%d)\n", identifier);
+	D(bug("MorphOSResourceLoadDelegate::didReceiveResponse(%d)\n", identifier));
 }
 
 void MorphOSResourceLoadDelegate::didReceiveContentLength(WebView *webView, unsigned long identifier, unsigned length, WebDataSource *dataSource)
 {
-	kprintf("MorphOSResourceLoadDelegate::didReceiveContentLength(%d)\n", identifier);
+	D(bug("MorphOSResourceLoadDelegate::didReceiveContentLength(%d)\n", identifier));
 }
 
 void MorphOSResourceLoadDelegate::didReceiveAuthenticationChallenge(WebView *webView, unsigned long identifier, WebURLAuthenticationChallenge *challenge, WebDataSource *dataSource)
 {
-	kprintf("MorphOSResourceLoadDelegate::didReceiveAuthenticationChallenge(%d)\n", identifier);
+	D(bug("MorphOSResourceLoadDelegate::didReceiveAuthenticationChallenge(%d)\n", identifier));
 }
 
 void MorphOSResourceLoadDelegate::didCancelAuthenticationChallenge(WebView *webView, unsigned long identifier, WebURLAuthenticationChallenge *challenge, WebDataSource *dataSource)
 {
-	kprintf("MorphOSResourceLoadDelegate::didCancelAuthenticationChallenge(%d)\n", identifier);
+	D(bug("MorphOSResourceLoadDelegate::didCancelAuthenticationChallenge(%d)\n", identifier));
 }
 
 void MorphOSResourceLoadDelegate::plugInFailedWithError(WebView *webView, WebError *error, WebDataSource *dataSource)
 {
-	kprintf("MorphOSResourceLoadDelegate::plugInFailedWithError()\n");
+	D(bug("MorphOSResourceLoadDelegate::plugInFailedWithError()\n"));
 }
 
 /******/
@@ -737,30 +741,30 @@ BalRectangle WebViewPrivate::onExpose(BalEventExpose event)
     GraphicsContext ctx(widget->cr);
 	IntRect rect(m_webView->dirtyRegion());
 
-	//kprintf("WebViewPrivate::onExpose(%d,%d,%d,%d)\n", rect.x(), rect.y(), rect.width(), rect.height());
+	//D(bug("WebViewPrivate::onExpose(%d,%d,%d,%d)\n", rect.x(), rect.y(), rect.width(), rect.height()));
 
 	if (frame->contentRenderer() && frame->view() && !rect.isEmpty() && !getv(widget->browser, MA_OWBBrowser_VideoElement))
 	{
 		bool coalesce = shouldCoalesce(rect);
 
-		if(renderBenchmark) { kprintf("dirtyRegion [%d %d %d %d] rects %d coalesce %d\n", rect.x(), rect.y(), rect.width(), rect.height(), m_dirtyRegions.size(), coalesce); } //
+		if(renderBenchmark) { D(bug("dirtyRegion [%d %d %d %d] rects %d coalesce %d\n", rect.x(), rect.y(), rect.width(), rect.height(), m_dirtyRegions.size(), coalesce)); } //
 
 		if(coalesce)
 		{
-			if(renderBenchmark) { kprintf("*** Coalescing rects\n"); } //
+			if(renderBenchmark) { D(bug("*** Coalescing rects\n")); } //
 
 			clearDirtyRegion();
 
 			frame->view()->updateLayoutAndStyleIfNeededRecursive();
 
-			if(renderBenchmark)	{ layout = currentTime() - start; start = currentTime(); kprintf("Painting [%d %d %d %d]\n", rect.x(), rect.y(), rect.width(), rect.height()); } //
+			if(renderBenchmark)	{ layout = currentTime() - start; start = currentTime(); D(bug("Painting [%d %d %d %d]\n", rect.x(), rect.y(), rect.width(), rect.height())); } //
 
 			ctx.save();
 			ctx.clip(rect);
 			frame->view()->paint(&ctx, rect);
 			ctx.restore();
 
-			if(renderBenchmark)	{ paint = currentTime() - start; start = currentTime(); kprintf("Painting inspector [%d %d %d %d]\n", rect.x(), rect.y(), rect.width(), rect.height()); } //
+			if(renderBenchmark)	{ paint = currentTime() - start; start = currentTime(); D(bug("Painting inspector [%d %d %d %d]\n", rect.x(), rect.y(), rect.width(), rect.height())); } //
 /*
 #if ENABLE(INSPECTOR)
 			ctx.save();
@@ -769,7 +773,7 @@ BalRectangle WebViewPrivate::onExpose(BalEventExpose event)
 			ctx.restore();
 #endif
 
-			if(renderBenchmark)	{ inspector = currentTime() - start; start = currentTime(); kprintf("Blitting [%d %d %d %d]\n", rect.x(), rect.y(), rect.width(), rect.height()); } //
+			if(renderBenchmark)	{ inspector = currentTime() - start; start = currentTime(); D(bug("Blitting [%d %d %d %d]\n", rect.x(), rect.y(), rect.width(), rect.height())); } //
 */
 			updateView(widget, rect, false);
 
@@ -777,7 +781,7 @@ BalRectangle WebViewPrivate::onExpose(BalEventExpose event)
 		}
 		else
 		{
-			if(renderBenchmark) { kprintf("*** Not Coalescing rects\n"); } //
+			if(renderBenchmark) { D(bug("*** Not Coalescing rects\n")); } //
 
 			Vector<IntRect> dirtyRegions = m_dirtyRegions; // urg
 			clearDirtyRegion();
@@ -788,7 +792,7 @@ BalRectangle WebViewPrivate::onExpose(BalEventExpose event)
 
 			for(size_t i = 0; i < dirtyRegions.size(); i++)
 			{
-				if(renderBenchmark) { kprintf("Painting [%d %d %d %d]\n", dirtyRegions[i].x(), dirtyRegions[i].y(), dirtyRegions[i].width(), dirtyRegions[i].height()); }
+				if(renderBenchmark) { D(bug("Painting [%d %d %d %d]\n", dirtyRegions[i].x(), dirtyRegions[i].y(), dirtyRegions[i].width(), dirtyRegions[i].height())); }
 				ctx.save();
 				ctx.clip(dirtyRegions[i]);
 				frame->view()->paint(&ctx, dirtyRegions[i]);
@@ -799,7 +803,7 @@ BalRectangle WebViewPrivate::onExpose(BalEventExpose event)
 				frame->page()->inspectorController()->drawHighlight(ctx);
 				ctx.restore();
 */
-				if(renderBenchmark)	{ paint += currentTime() - start; start = currentTime(); kprintf("Blitting [%d %d %d %d]\n", dirtyRegions[i].x(), dirtyRegions[i].y(), dirtyRegions[i].width(), dirtyRegions[i].height()); } //
+				if(renderBenchmark)	{ paint += currentTime() - start; start = currentTime(); D(bug("Blitting [%d %d %d %d]\n", dirtyRegions[i].x(), dirtyRegions[i].y(), dirtyRegions[i].width(), dirtyRegions[i].height())); } //
 
 				updateView(widget, dirtyRegions[i], false);
 
@@ -814,14 +818,14 @@ BalRectangle WebViewPrivate::onExpose(BalEventExpose event)
 
     if(renderBenchmark)
 	{
-		kprintf("WebViewPrivate::onExpose(%d,%d,%d,%d)\n  Layout: %f ms\n  Paint: %f ms\n  Inspector: %f ms\n  Blit: %f ms\n->Total: %f ms\n\n",
+		D(bug("WebViewPrivate::onExpose(%d,%d,%d,%d)\n  Layout: %f ms\n  Paint: %f ms\n  Inspector: %f ms\n  Blit: %f ms\n->Total: %f ms\n\n",
 			rect.x(), rect.y(), rect.width(), rect.height(),
 			layout*1000,
 			paint*1000,
 			inspector*1000,
 			blit*1000,
 			(layout + paint + blit + inspector)*1000
-			);
+			));
 	}
 
 	return rect;
@@ -1193,20 +1197,20 @@ bool WebViewPrivate::onKeyDown(BalEventKey event)
 			{
 				MemoryCache::Statistics stats = memoryCache()->getStatistics();
 
-				kprintf("Statistics about cache:\n");
-				kprintf("\timages: count=%d - size=%d - liveSize=%d - decodedSize=%d\n", stats.images.count, stats.images.size, stats.images.liveSize, stats.images.decodedSize);
-				kprintf("\tcssStyleSheets: count=%d - size=%d - liveSize=%d - decodedSize=%d\n", stats.cssStyleSheets.count, stats.cssStyleSheets.size, stats.cssStyleSheets.liveSize, stats.cssStyleSheets.decodedSize);
-				kprintf("\tscripts: count=%d - size=%d - liveSize=%d - decodedSize=%d\n", stats.scripts.count, stats.scripts.size, stats.scripts.liveSize, stats.scripts.decodedSize);
-				kprintf("\tfonts: count=%d - size=%d - liveSize=%d - decodedSize=%d\n", stats.fonts.count, stats.fonts.size, stats.fonts.liveSize, stats.fonts.decodedSize);
+				D(bug("Statistics about cache:\n"));
+				D(bug("\timages: count=%d - size=%d - liveSize=%d - decodedSize=%d\n", stats.images.count, stats.images.size, stats.images.liveSize, stats.images.decodedSize));
+				D(bug("\tcssStyleSheets: count=%d - size=%d - liveSize=%d - decodedSize=%d\n", stats.cssStyleSheets.count, stats.cssStyleSheets.size, stats.cssStyleSheets.liveSize, stats.cssStyleSheets.decodedSize));
+				D(bug("\tscripts: count=%d - size=%d - liveSize=%d - decodedSize=%d\n", stats.scripts.count, stats.scripts.size, stats.scripts.liveSize, stats.scripts.decodedSize));
+				D(bug("\tfonts: count=%d - size=%d - liveSize=%d - decodedSize=%d\n", stats.fonts.count, stats.fonts.size, stats.fonts.liveSize, stats.fonts.decodedSize));
 
-				kprintf("Statistics about JavaScript:\n");
+				D(bug("Statistics about JavaScript:\n"));
 
 				HeapInfo heapInfo;
 				ScriptGCEvent::getHeapSize(heapInfo);
 
-				kprintf("\theap: used %d - total %d\n", heapInfo.usedJSHeapSize, heapInfo.totalJSHeapSize);
+				D(bug("\theap: used %d - total %d\n", heapInfo.usedJSHeapSize, heapInfo.totalJSHeapSize));
 
-				kprintf("Running Garbage collector now.\n");
+				D(bug("Running Garbage collector now.\n"));
 				
 				int savedPageCacheCapacity = pageCache()->capacity();
 				pageCache()->setCapacity(0);
@@ -1430,7 +1434,7 @@ void WebViewPrivate::popupMenuShow(void *popupInfo)
 
 void WebViewPrivate::updateView(BalWidget *widget, IntRect rect, bool sync)
 {
-	// kprintf("updateview(%p (%p),(%d,%d,%d,%d))\n", widget, widget?widget->window:NULL, rect.x(), rect.y(), rect.width(), rect.height());
+	// D(bug("updateview(%p (%p),(%d,%d,%d,%d))\n", widget, widget?widget->window:NULL, rect.x(), rect.y(), rect.width(), rect.height()));
 
     if (!widget || !widget->window || rect.isEmpty())
         return;
@@ -1450,14 +1454,14 @@ void WebViewPrivate::sendExposeEvent(IntRect)
 
 void WebViewPrivate::repaint(const WebCore::IntRect& windowRect, bool contentChanged, bool immediate, bool repaintContentOnly)
 {
-	// kprintf("WebViewPrivate::repaint([%d %d %d %d], %d, %d , %d\n", windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), contentChanged, immediate, repaintContentOnly);
+	// D(bug("WebViewPrivate::repaint([%d %d %d %d], %d, %d , %d\n", windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), contentChanged, immediate, repaintContentOnly));
 
     if (windowRect.isEmpty())
         return;
     IntRect rect = windowRect;
     rect.intersect(m_rect);
 
-	// kprintf("repaint: contentChanged %d immediate %d repaintContentOnly %d\n", contentChanged, immediate, repaintContentOnly);
+	// D(bug("repaint: contentChanged %d immediate %d repaintContentOnly %d\n", contentChanged, immediate, repaintContentOnly));
 
     if (rect.isEmpty())
         return;
@@ -1503,10 +1507,10 @@ void WebViewPrivate::scrollBackingStore(WebCore::FrameView* view, int dx, int dy
 	if(renderBenchmark)
 	{
 		start = currentTime();
-		kprintf("WebViewPrivate::scrollBackingStore(%d, %d, scrollViewRect[%d, %d, %d, %d], clipRect[%d, %d, %d, %d])\n", dx, dy,
+		D(bug("WebViewPrivate::scrollBackingStore(%d, %d, scrollViewRect[%d, %d, %d, %d], clipRect[%d, %d, %d, %d])\n", dx, dy,
 								scrollViewRect.x(), scrollViewRect.y(), scrollViewRect.width(), scrollViewRect.height(),
-								clipRect.x(), clipRect.y(), clipRect.width(), clipRect.height());
-		kprintf("  dirtyRegion [%d, %d, %d, %d]\n", m_webView->dirtyRegion().x, m_webView->dirtyRegion().y, m_webView->dirtyRegion().w, m_webView->dirtyRegion().h);
+								clipRect.x(), clipRect.y(), clipRect.width(), clipRect.height()));
+		D(bug("  dirtyRegion [%d, %d, %d, %d]\n", m_webView->dirtyRegion().x, m_webView->dirtyRegion().y, m_webView->dirtyRegion().w, m_webView->dirtyRegion().h));
 	}
 
 	m_backingStoreDirtyRegion.move(dx, dy);
@@ -1556,13 +1560,13 @@ void WebViewPrivate::scrollBackingStore(WebCore::FrameView* view, int dx, int dy
         dirtyH = dy;
     }
 
-	//kprintf("new dirtyRegion [%d, %d, %d, %d]\n", dirtyX, dirtyY, dirtyW, dirtyH);
+	//D(bug("new dirtyRegion [%d, %d, %d, %d]\n", dirtyX, dirtyY, dirtyW, dirtyH));
 
 	if (dirtyX || dirtyY || dirtyW || dirtyH)
 	{
 		WebCore::IntRect r = WebCore::IntRect(x, y, width, height);
 
-		if(renderBenchmark) { kprintf("  Scroll d=[%d %d] r=[%d, %d, %d, %d]\n", dx, dy, r.x(), r.y(), r.width(), r.height()); } //
+		if(renderBenchmark) { D(bug("  Scroll d=[%d %d] r=[%d, %d, %d, %d]\n", dx, dy, r.x(), r.y(), r.width(), r.height())); } //
 
 		DoMethod(widget->browser, MM_OWBBrowser_Scroll, dx, dy, &r);
         m_webView->addToDirtyRegion(IntRect(dirtyX, dirtyY, dirtyW, dirtyH));
@@ -1575,12 +1579,12 @@ void WebViewPrivate::scrollBackingStore(WebCore::FrameView* view, int dx, int dy
 	// Sync scrollers here (less lag feeling that way, since the rest isn't synchron)
 	DoMethod(widget->browser, MM_OWBBrowser_UpdateScrollers);
 
-	//kprintf("new dirtyRegion [%d, %d, %d, %d]\n", m_webView->dirtyRegion().x, m_webView->dirtyRegion().y, m_webView->dirtyRegion().w, m_webView->dirtyRegion().h);
+	//D(bug("new dirtyRegion [%d, %d, %d, %d]\n", m_webView->dirtyRegion().x, m_webView->dirtyRegion().y, m_webView->dirtyRegion().w, m_webView->dirtyRegion().h));
 
 	sendExposeEvent(updateRect); // only processed at next expose event, potential lag
 	//onExpose(0);               // immediate, but scrolling sideffect with fixed elements
 
-   if(renderBenchmark) { kprintf("WebViewPrivate::scrollBackingStore()\n  Scroll: %f ms\n", currentTime() - start); } //
+   if(renderBenchmark) { D(bug("WebViewPrivate::scrollBackingStore()\n  Scroll: %f ms\n", currentTime() - start)); } //
 }
 
 /* Implement these properly */

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/appclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/appclass.cpp
@@ -118,9 +118,15 @@
 #include "asl.h"
 #include "ExtCredential.h"
 
-
-#define D(x)
 #undef String
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
 
 
 /******************************************************************
@@ -1118,7 +1124,7 @@ DEFDISP
 	removeClipboardMonitor();
 	#endif
 	
-	//kprintf("OWBApp: Ok, calling supermethod\n");
+	//D(bug("OWBApp: Ok, calling supermethod\n"));
 
 	return DOSUPER;
 }
@@ -2521,15 +2527,15 @@ DEFSMETHOD(OWBApp_SetFormState)
 	Document *doc = (Document *) msg->doc;
 	String strippedURL = stripURL(KURL(ParsedURLString, *host)).string();
 
-	D(kprintf("SetFormState for URL <%s>\nStripped <%s>\n", host->latin1().data(), strippedURL.latin1().data()));
+	D(bug("SetFormState for URL <%s>\nStripped <%s>\n", host->latin1().data(), strippedURL.latin1().data()));
 
 	ExtCredential *credential = (ExtCredential *) DoMethod(data->passwordmanagerwin, MM_PasswordManagerGroup_Get, &strippedURL);
 
-	D(kprintf("Found Form credential? %p\n", credential));
+	D(bug("Found Form credential? %p\n", credential));
 
 	if (credential && credential->type() == CREDENTIAL_TYPE_FORM && credential->flags() != CREDENTIAL_FLAG_BLACKLISTED)
 	{
-		D(kprintf("user <%s> password <%s>\n", credential->user().utf8().data(), credential->password().utf8().data()));
+		D(bug("user <%s> password <%s>\n", credential->user().utf8().data(), credential->password().utf8().data()));
 
 		// Iterate through all forms
 		RefPtr<HTMLCollection> forms = doc->forms();
@@ -2601,7 +2607,7 @@ DEFSMETHOD(OWBApp_SaveFormState)
 
 				if (webFormPasswordData.isValid())
 				{
-					D(kprintf("Valid formdata found for <%s>\n", webFormPasswordData.origin.string().latin1().data()));
+					D(bug("Valid formdata found for <%s>\n", webFormPasswordData.origin.string().latin1().data()));
 
 					if(getv(app, MA_OWBApp_SaveFormCredentials) && DoMethod(data->passwordmanagerwin, MM_PasswordManagerGroup_Get, &(webFormPasswordData.origin.string())) == NULL)
 					{
@@ -2612,7 +2618,7 @@ DEFSMETHOD(OWBApp_SaveFormState)
 													webFormPasswordData.passwordElement,
 													0);
 
-						D(kprintf("Credentials ElementNames [%s : %s] ElementValues [%s : %s]\n", webFormPasswordData.userNameElement.latin1().data(), webFormPasswordData.userNameValue.latin1().data(), webFormPasswordData.passwordElement.latin1().data(), webFormPasswordData.passwordValue.latin1().data()));
+						D(bug("Credentials ElementNames [%s : %s] ElementValues [%s : %s]\n", webFormPasswordData.userNameElement.latin1().data(), webFormPasswordData.userNameValue.latin1().data(), webFormPasswordData.passwordElement.latin1().data(), webFormPasswordData.passwordValue.latin1().data()));
 
 						if (!extCredential.isEmpty())
 						{
@@ -2921,9 +2927,9 @@ DEFSMETHOD(OWBApp_RequestPolicyForMimeType)
 	    path =  decodeURLEscapeSequences(path);
 	}
 
-	//kprintf("OWBApp_RequestPolicyForMimeType mimetype <%s> url <%s> attachment %d path <%s>\n", mimetype.utf8().data(), urlstring.utf8().data(), response->isAttachment(), path.latin1().data());
-	//kprintf("IsSupportedMediaMIMEType(%s): %d\n", mimetype.utf8().data(), MIMETypeRegistry::isSupportedMediaMIMEType(mimetype));
-	//kprintf("WebView::canShowMIMEType(%s): %d\n", mimetype.utf8().data(), webView->canShowMIMEType(mimetype.utf8().data()));
+	//D(bug("OWBApp_RequestPolicyForMimeType mimetype <%s> url <%s> attachment %d path <%s>\n", mimetype.utf8().data(), urlstring.utf8().data(), response->isAttachment(), path.latin1().data()));
+	//D(bug("IsSupportedMediaMIMEType(%s): %d\n", mimetype.utf8().data(), MIMETypeRegistry::isSupportedMediaMIMEType(mimetype)));
+	//D(bug("WebView::canShowMIMEType(%s): %d\n", mimetype.utf8().data(), webView->canShowMIMEType(mimetype.utf8().data())));
 
 /* Honour attachment attribute */
 	if(response->isAttachment())
@@ -2947,7 +2953,7 @@ DEFSMETHOD(OWBApp_RequestPolicyForMimeType)
 		}
 	}
 
-	//kprintf("1 matching_mn %p <%s>\n", matching_mn, matching_mn?matching_mn->mimetype:"");
+	//D(bug("1 matching_mn %p <%s>\n", matching_mn, matching_mn?matching_mn->mimetype:""));
 
 	/* Search again with family match */
 	if(!matching_mn)
@@ -2975,7 +2981,7 @@ DEFSMETHOD(OWBApp_RequestPolicyForMimeType)
 		}
 	}
 
-	//kprintf("2 matching_mn %p <%s>\n", matching_mn, matching_mn?matching_mn->mimetype:"");
+	//D(bug("2 matching_mn %p <%s>\n", matching_mn, matching_mn?matching_mn->mimetype:""));
 
 	/* Extension check in text/plain case, to handle bad text/html mimetype responses */
 	if((matching_mn && (equalIgnoringCase(String(matching_mn->mimetype), "text/html") ||
@@ -2988,14 +2994,14 @@ DEFSMETHOD(OWBApp_RequestPolicyForMimeType)
 	{
 	    int pos = path.reverseFind('.');
 
-		//kprintf("looking for extension now...\n");
+		//D(bug("looking for extension now...\n"));
 
 		if (pos >= 0)
 		{
 			bool found = false;
 	        String extension = path.substring(pos + 1);
 
-			//kprintf("extension %s\n", extension.utf8().data());
+			//D(bug("extension %s\n", extension.utf8().data()));
 
 			ITERATELIST(n, &mimetype_list)
 			{
@@ -3006,11 +3012,11 @@ DEFSMETHOD(OWBApp_RequestPolicyForMimeType)
 
 				for(unsigned int i = 0; i < listExtensions.size(); i++)
 				{
-					//kprintf("checking extension %s (mimetype %s)\n", listExtensions[i].utf8().data(), mn->mimetype);
+					//D(bug("checking extension %s (mimetype %s)\n", listExtensions[i].utf8().data(), mn->mimetype));
 
 					if(equalIgnoringCase(listExtensions[i], extension))
 					{
-						//kprintf("found !\n");
+						//D(bug("found !\n"));
 						matching_mn = mn;
 						found = true;
 						break;
@@ -3023,7 +3029,7 @@ DEFSMETHOD(OWBApp_RequestPolicyForMimeType)
 		}	 
 	}
 
-	//kprintf("3 matching_mn %p <%s>\n", matching_mn, matching_mn?matching_mn->mimetype:"");
+	//D(bug("3 matching_mn %p <%s>\n", matching_mn, matching_mn?matching_mn->mimetype:""));
 
 	if(matching_mn)
 	{
@@ -3163,7 +3169,7 @@ DEFSMETHOD(OWBApp_RequestPolicyForMimeType)
 		return TRUE;
 	}
 
-	//kprintf("Nothing found in mimetypes, fallback to default behaviour (canShow: %d)\n", webView->canShowMIMEType(type));
+	//D(bug("Nothing found in mimetypes, fallback to default behaviour (canShow: %d)\n", webView->canShowMIMEType(type)));
 
 /* Fall back to default behaviour */
 
@@ -3341,7 +3347,7 @@ DEFSMETHOD(OWBApp_RestoreSession)
 
 DEFSMETHOD(OWBApp_SaveSession)
 {
-	//kprintf("OWBApp_SaveSession\n");
+	//D(bug("OWBApp_SaveSession\n"));
 
 	String sessionfile = SESSION_PATH;
 

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/asl.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/asl.cpp
@@ -36,7 +36,13 @@
 #include <proto/intuition.h>
 #include <clib/macros.h>
 
-#include <clib/debug_protos.h>
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
 
 #include "gui.h"
 #include "asl.h"
@@ -136,7 +142,7 @@ ULONG asl_run_multiple(STRPTR p, struct TagItem *tags, char *** files, ULONG rem
 							if((*files)[i])
 							{
 								strcpy((*files)[i], buf);
-								//kprintf("selected file %d <%s>\n", i, (*files)[i]);
+								//D(bug("selected file %d <%s>\n", i, (*files)[i]));
 							}
 						}
 					}

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/autofillpopupclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/autofillpopupclass.cpp
@@ -30,10 +30,14 @@
 #include "GraphicsContext.h"
 
 #include <mui/Calltips_mcc.h>
-#include <clib/debug_protos.h>
 
 #include "gui.h"
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 using namespace WebCore;

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/bookmarkgroupclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/bookmarkgroupclass.cpp
@@ -46,7 +46,13 @@
 #define get(obj,attr,store) GetAttr(attr,obj,(ULONG *)store)
 #endif
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
+
 
 /* public */
 #include <mui/Listtree_mcc.h>
@@ -144,7 +150,7 @@ int parsevarpool(STRPTR var,char *temp,...)
                 {
 					if (pkey==lkey && lkey>0) p[lp-lkey]='\0';
 					else p[lp]='\0';
-					//D(kprintf("Found Key, string is %s\n",&p[0]));
+					//D(bug("Found Key, string is %s\n",&p[0]));
                     switch (type)
                     {
                         case -1 :
@@ -157,7 +163,7 @@ int parsevarpool(STRPTR var,char *temp,...)
 							
 							arg_int=NULL;
                             arg_int = va_arg(pp, int *);
-							//D(kprintf("Valeur int: %ld arg is %08lx\n", l, arg_int));
+							//D(bug("Valeur int: %ld arg is %08lx\n", l, arg_int));
 							if (arg_int)
 							{	
 								*arg_int=l;
@@ -177,7 +183,7 @@ int parsevarpool(STRPTR var,char *temp,...)
                     }
 					if (*var==0)
 					{
-						//D(kprintf("end if string parse var return %ld\n",n));
+						//D(bug("end if string parse var return %ld\n",n));
 						return n;
 					}
 					else next=1;
@@ -191,7 +197,7 @@ int parsevarpool(STRPTR var,char *temp,...)
         }
     }
     va_end(pp);
-	//D(kprintf("parse var return %ld\n",n));
+	//D(bug("parse var return %ld\n",n));
     //if (strlen(temp)) PF("#### Parsevar end with unparse \"%s\"\n",temp);
     return(n);
 }
@@ -224,7 +230,7 @@ static void doset(Object *obj, struct Data *data, struct TagItem *tags)
 			break;
 		case MA_Bookmarkgroup_Alias:
 			current=NULL;
-			D(kprintf("Set Alias '%s'\n", tag->ti_Data));
+			D(bug("Set Alias '%s'\n", tag->ti_Data));
 			if (DoMethod(data->lt_linklist, MUIM_List_GetEntry, MUIV_List_GetEntry_Active, &current) && (current))
 			{
 				APTR n;
@@ -281,10 +287,10 @@ static void doset(Object *obj, struct Data *data, struct TagItem *tags)
 			if(active)
 			{
 				current=(struct treedata *)active->tn_User;   
-				D(kprintf( "InMenu before is %08lx.\n",(ULONG)current->flags));
+				D(bug( "InMenu before is %08lx.\n",(ULONG)current->flags));
 				if (tag->ti_Data) current->flags = (current->flags & ~NODEFLAG_INMENU) | NODEFLAG_INMENU;
 				else current->flags = current->flags & ~NODEFLAG_INMENU;
-				D(kprintf( "InMenu after is %08lx.\n",(ULONG)current->flags));
+				D(bug( "InMenu after is %08lx.\n",(ULONG)current->flags));
 				line=DoMethod(data->lt_bookmark, MUIM_Listtree_GetNr, active, 0L);
 				DoMethod(data->lt_bookmark, MUIM_List_Redraw, line, NULL);
 				DoMethod(app, MUIM_Application_PushMethod,
@@ -301,7 +307,7 @@ static void doset(Object *obj, struct Data *data, struct TagItem *tags)
 			{
 				current=(struct treedata *)active->tn_User;
 				current->treenode = active;
-				D(kprintf( "QLink before is %08lx.\n",(ULONG)current->flags));
+				D(bug( "QLink before is %08lx.\n",(ULONG)current->flags));
 				if (tag->ti_Data!=(current->flags & NODEFLAG_QUICKLINK))
 				{
 					if (tag->ti_Data!=0)
@@ -313,7 +319,7 @@ static void doset(Object *obj, struct Data *data, struct TagItem *tags)
 						DoMethod(obj, MM_Bookmarkgroup_RemoveQuickLink, current);
 					}
 				}
-				D(kprintf( "QLink after is %08lx.\n",(ULONG)current->flags));
+				D(bug( "QLink after is %08lx.\n",(ULONG)current->flags));
 			}
 			break;
 	}
@@ -511,10 +517,10 @@ DEFNEW
 DEFDISP
 {
 	//GETDATA;
-	D(kprintf("OWB Bookmark test app: disposing\n"));
+	D(bug("OWB Bookmark test app: disposing\n"));
 	//dosnotify_stop(data->notifyreq);
 	DoMethod(obj, MM_Bookmarkgroup_SaveHtml, BOOKMARK_PATH, MV_Bookmark_SaveHtml_OWB);
-	D(kprintf("OWB Bookmark test app: ok, calling supermethod\n"));
+	D(bug("OWB Bookmark test app: ok, calling supermethod\n"));
 	return DOSUPER;
 }
 
@@ -628,7 +634,7 @@ DEFSMETHOD(Bookmarkgroup_Update)
 	GETDATA;
 	struct MUIS_Listtree_TreeNode *active = NULL, *parent = NULL;
 	struct treedata *current;
-	D(kprintf("Bookmarkgroup_Update %ld\n", msg->from));
+	D(bug("Bookmarkgroup_Update %ld\n", msg->from));
 	if (msg->from & MV_BookmarkGroup_Update_Tree)
 	{
 		active = (struct MUIS_Listtree_TreeNode *) DoMethod(data->lt_bookmark, MUIM_Listtree_GetEntry, NULL, MUIV_Listtree_GetEntry_Position_Active, 0);
@@ -719,12 +725,12 @@ DEFSMETHOD(Bookmarkgroup_Update)
 			set(data->bt_removeql,  MUIA_Disabled, FALSE); 	
 			if (current->alias)
 			{
-				D(kprintf("Alias is '%s'\n", current->alias));
+				D(bug("Alias is '%s'\n", current->alias));
 				nnset(data->st_alias, MUIA_String_Contents, current->alias);
 			}
 			else
 			{
-				D(kprintf("Alias is null\n"));
+				D(bug("Alias is null\n"));
 				nnset(data->st_alias, MUIA_String_Contents, "");
 			}
 			if ((data->win) && !(msg->from & MV_BookmarkGroup_Update_Tree)) DoMethod(data->win,	MUIM_Set, MUIA_Window_ActiveObject, data->st_alias);
@@ -758,7 +764,7 @@ DEFSMETHOD(Bookmarkgroup_AddGroup)
 	if (!msg->title) newnode.title="";
 	else newnode.title=(char *) msg->title;
 
-	D(kprintf("AddGroup title %s\n",msg->title));
+	D(bug("AddGroup title %s\n",msg->title));
 
 	active = (struct MUIS_Listtree_TreeNode *) DoMethod(data->lt_bookmark, MUIM_Listtree_GetEntry, NULL, MUIV_Listtree_GetEntry_Position_Active, 0);
 
@@ -805,7 +811,7 @@ DEFSMETHOD(Bookmarkgroup_AddGroup)
 		);
 	}
 
-	D(kprintf("entry is %08lx.\n",(ULONG)entry));
+	D(bug("entry is %08lx.\n",(ULONG)entry));
 	
 	set(data->lt_bookmark, MUIA_Listtree_Quiet, FALSE);
 	
@@ -849,12 +855,12 @@ DEFSMETHOD(Bookmarkgroup_AddLink)
 	caddress = newnode.address;
 	calias   = newnode.alias;
 	
-	D(kprintf("AddLink title %s %08lx %08lx\n",msg->title, (ULONG)msg->alias, (ULONG)msg->address));
+	D(bug("AddLink title %s %08lx %08lx\n",msg->title, (ULONG)msg->alias, (ULONG)msg->address));
 	
 	if (!msg->external)
 	{
 		active = (struct MUIS_Listtree_TreeNode *) DoMethod(data->lt_bookmark, MUIM_Listtree_GetEntry, NULL, MUIV_Listtree_GetEntry_Position_Active, 0);
-		D(kprintf("Active is %08lx.\n",(ULONG)active));
+		D(bug("Active is %08lx.\n",(ULONG)active));
 	}
 
 	// Disable notifications
@@ -904,7 +910,7 @@ DEFSMETHOD(Bookmarkgroup_AddLink)
 	free(calias);
 	free(caddress);
 
-	D(kprintf( "entry is %08lx.\n",(ULONG)entry));
+	D(bug( "entry is %08lx.\n",(ULONG)entry));
 	set(data->lt_bookmark, MUIA_Listtree_Quiet, FALSE);	
 	if (entry)
 	{
@@ -940,11 +946,11 @@ DEFTMETHOD(Bookmarkgroup_AddSeparator)
 	newnode.iconimg = NULL;
 	newnode.tree    = data->lt_bookmark;
 	
-	D(kprintf("AddSeparator\n"));
+	D(bug("AddSeparator\n"));
 	
 	active = (struct MUIS_Listtree_TreeNode *) DoMethod(data->lt_bookmark, MUIM_Listtree_GetEntry, NULL, MUIV_Listtree_GetEntry_Position_Active, 0);
 	
-	D(kprintf("Active is %08lx.\n",(ULONG)active));
+	D(bug("Active is %08lx.\n",(ULONG)active));
 	
 	// Disable notifications
 	set(data->lt_bookmark, MUIA_Listtree_Quiet, TRUE); 	 
@@ -989,7 +995,7 @@ DEFTMETHOD(Bookmarkgroup_AddSeparator)
 		);
 	}
 
-	D(kprintf( "entry is %08lx.\n",(ULONG)entry));
+	D(bug( "entry is %08lx.\n",(ULONG)entry));
 	set(data->lt_bookmark, MUIA_Listtree_Quiet, FALSE);	
 	if (entry)
 	{
@@ -1054,7 +1060,7 @@ DEFTMETHOD(Bookmarkgroup_ReadQLOrder)
 	GETDATA;
 	struct treedata *td;
 	ULONG count,max=0,change=FALSE;
-	D(kprintf("Bookmarkgroup ReadQLOrder\n"));
+	D(bug("Bookmarkgroup ReadQLOrder\n"));
 	get(data->lt_linklist, MUIA_List_Entries, &max);
 	
 	for (count=0;count<max;count++)
@@ -1082,7 +1088,7 @@ DEFTMETHOD(Bookmarkgroup_ReadQLOrder)
 	}
 	else
 	{
-		D(kprintf("ReadQLOrder no change\n"));
+		D(bug("ReadQLOrder no change\n"));
 	}
 	return (0);
 }
@@ -1127,7 +1133,7 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 			if (p==3)
 			{
 				q=0;
-				D(kprintf( "Parse Link: '%s'\n", ptr[2]));
+				D(bug( "Parse Link: '%s'\n", ptr[2]));
 
 				if (strcmp(ptr[2],"----------------------------------------")==0)
 				{
@@ -1159,7 +1165,7 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 				if (q==2)
 				{
 					// Alias
-					D(kprintf( "    Alias: '%s'\n", ptr[3]));
+					D(bug( "    Alias: '%s'\n", ptr[3]));
 					newnode.alias=ptr[3];
 					p++;
 				}
@@ -1169,7 +1175,7 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 					q=parsevarpool(ptr[1], "%.OWBQUICKLINK=\"%s\"", &ptr[3]);
 					if (q==2)
 					{
-						D(kprintf( "QuickLink: '%s'\n", ptr[3]));
+						D(bug( "QuickLink: '%s'\n", ptr[3]));
 						newnode.alias=ptr[3];
 						p++;
 						newnode.flags|=NODEFLAG_QUICKLINK;
@@ -1178,22 +1184,22 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 						if (q==2)
 						{
 							newnode.ql_order=order;
-							D(kprintf("Order: %ld\n",order));
+							D(bug("Order: %ld\n",order));
 						}
 						else
 						{
-							D(kprintf("Fail get order '%s'\n", ptr[1]));
+							D(bug("Fail get order '%s'\n", ptr[1]));
 						}
 
 						q=parsevarpool(ptr[1], "%.OWBQLSHOWALIAS=\"%d\"", &showalias);
 						if (q==2)
 						{
 							newnode.showalias=showalias;
-							D(kprintf("Show Alias: %ld\n",showalias));
+							D(bug("Show Alias: %ld\n",showalias));
 						}
 						else
 						{
-							D(kprintf("Fail get show alias '%s'\n", ptr[1]));
+							D(bug("Fail get show alias '%s'\n", ptr[1]));
 						}
 					}
 					else
@@ -1205,7 +1211,7 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 				q=parsevarpool(ptr[1], "%.IBHLFLAGS=\"%s\"", &ptr[4]);
 				if (q==2)
 				{
-					D(kprintf( "Flags: '%s'\n", ptr[4]));
+					D(bug( "Flags: '%s'\n", ptr[4]));
 					FreeVecTaskPooled(ptr[4]); ptr[4]=NULL;
 				}
 				else
@@ -1246,7 +1252,7 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 				p--;
 				if (p==2)
 				{
-					D(kprintf( "Parse Group: '%s'\n", ptr[1]));
+					D(bug( "Parse Group: '%s'\n", ptr[1]));
 					newnode.flags=NODEFLAG_GROUP;
 					newnode.title=ptr[1];
 					newnode.alias=NULL;
@@ -1260,7 +1266,7 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 					q=parsevarpool(ptr[0], "%.IBHLFLAGS=\"%s\"", &ptr[4]);
 					if (q==2)
 					{
-						D(kprintf( "Flags: '%s'\n", ptr[4]));
+						D(bug( "Flags: '%s'\n", ptr[4]));
 						FreeVecTaskPooled(ptr[4]); ptr[4]=NULL;
 					}
 					else
@@ -1272,7 +1278,7 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 					q=parsevarpool(ptr[0], "%.OWBQUICKLINK=\"%s\"", &ptr[4]);
 					if (q==2)
 					{
-						D(kprintf( "QuickLink: '%s'\n", ptr[4]));
+						D(bug( "QuickLink: '%s'\n", ptr[4]));
 						newnode.alias=ptr[4];
 						p++;
 						newnode.flags|=NODEFLAG_QUICKLINK;
@@ -1281,22 +1287,22 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 						if (q==2)
 						{
 							newnode.ql_order=order;
-							D(kprintf("Order: %ld\n",order));
+							D(bug("Order: %ld\n",order));
 						}
 						else
 						{
-							D(kprintf("Fail get order '%s'\n", ptr[0]));
+							D(bug("Fail get order '%s'\n", ptr[0]));
 						}
 
 						q=parsevarpool(ptr[1], "%.OWBQLSHOWALIAS=\"%d\"", &showalias);
 						if (q==2)
 						{
 							newnode.showalias=showalias;
-							D(kprintf("Show Alias: %ld\n",showalias));
+							D(bug("Show Alias: %ld\n",showalias));
 						}
 						else
 						{
-							D(kprintf("Fail get show alias '%s'\n", ptr[1]));
+							D(bug("Fail get show alias '%s'\n", ptr[1]));
 						}
 					}
 					else
@@ -1330,7 +1336,7 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 			{
 				if (strstr(line, "</UL>"))
 				{
-					D(kprintf( "Parse End Group\n"));
+					D(bug( "Parse End Group\n"));
 					if(group != NULL)
 					{
 						group = (MUIS_Listtree_TreeNode *) DoMethod(data->lt_bookmark, MUIM_Listtree_GetEntry, group, MUIV_Listtree_GetEntry_Position_Parent, 0);
@@ -1467,7 +1473,7 @@ DEFSMETHOD(Bookmarkgroup_SaveHtml)
 	{
 		if (msg->type==MV_Bookmark_SaveHtml_OWB)
 		{
-			D(kprintf("Save OWB bookmark in %s\n", msg->file));
+			D(bug("Save OWB bookmark in %s\n", msg->file));
 			FPuts(html,"<!-- OWB MorphOS Bookmark V1 -->\n");
 			FPuts(html,"<HTML>\n");
 			FPuts(html,"<HEAD><TITLE>OWB MorphOS Bookmark</TITLE></HEAD>\n");
@@ -1521,7 +1527,7 @@ DEFTMETHOD(Bookmarkgroup_AutoSave)
 	}
 	else
 	{
-		D(kprintf("Dual call to auto save\n"));
+		D(bug("Dual call to auto save\n"));
 	}
 	return (0);
 }
@@ -1565,13 +1571,13 @@ BOOL MyStrCpyOnly(STRPTR *d, STRPTR s)
 {
     if (!s)
     {
-		D(kprintf("## Source is NULL!\n"));
+		D(bug("## Source is NULL!\n"));
         return(FALSE);
     }
     *d=(char *)malloc(strlen(s)+1);
     if (*d==NULL)
     {
-		D(kprintf("## No memory for Destination!\n"));
+		D(bug("## No memory for Destination!\n"));
         return(FALSE);
     }
     strcpy(*d,s);
@@ -1604,7 +1610,7 @@ static void build_menu(Object *menu, Object *lt, struct MUIS_Listtree_TreeNode *
 
 						if(submenu)
 						{
-							D(kprintf("Add sub menu\n"));
+							D(bug("Add sub menu\n"));
 							DoMethod(menu, MUIM_Family_AddTail, submenu);
 							build_menu(submenu, lt, tn);
 						}
@@ -1621,7 +1627,7 @@ static void build_menu(Object *menu, Object *lt, struct MUIS_Listtree_TreeNode *
 						if(node->flags & NODEFLAG_BAR)
 						{
 							// Add separator
-							D(kprintf("Add separator\n"));
+							D(bug("Add separator\n"));
 							item = MenuitemObject,
 			                    MUIA_Menuitem_Title,  NM_BARLABEL,
 								MUIA_UserData, NULL,
@@ -1643,7 +1649,7 @@ static void build_menu(Object *menu, Object *lt, struct MUIS_Listtree_TreeNode *
 							if (node->address) MyStrCpyOnly(&address,node->address);
 							else MyStrCpyOnly(&address,"");
 							
-							D(kprintf("Add link\n"));
+							D(bug("Add link\n"));
 
 							// truncate title
 							truncatedTitle = title;
@@ -1739,7 +1745,7 @@ struct  MUIP_Family_GetChild                { ULONG MethodID; LONG nr; Object *r
 DEFTMETHOD(Bookmarkgroup_UpdateMenu)
 {
 	GETDATA;
-	D(kprintf("Bookmark UpdateMenu\n"));
+	D(bug("Bookmark UpdateMenu\n"));
 
 	FORCHILD(app, MUIA_Application_WindowList)
 	{
@@ -1788,7 +1794,7 @@ DEFSMETHOD(Bookmarkgroup_AddQuickLink)
 	struct MUIS_Listtree_TreeNode *tn;
 	struct treedata *node=NULL;
 
-	D(kprintf("\nBookmarkGroup AddQuickLink in pos %ld\n",msg->pos));
+	D(bug("\nBookmarkGroup AddQuickLink in pos %ld\n",msg->pos));
 	if (msg->node)
 	{
 		// Use the one provided
@@ -1807,7 +1813,7 @@ DEFSMETHOD(Bookmarkgroup_AddQuickLink)
 	if ((node) && (node->flags & NODEFLAG_NOTATTACHED))
 	{
 		// Link from other add to bookmark
-		D(kprintf("External node, add it to bookmark\n"));
+		D(bug("External node, add it to bookmark\n"));
 		node=(struct treedata *)DoMethod(obj, MM_Bookmarkgroup_AddLink, node->title, node->alias, node->address, TRUE, TRUE, FALSE);
 	}
 
@@ -1831,7 +1837,7 @@ DEFSMETHOD(Bookmarkgroup_AddQuickLink)
 				temp[size-3]='.';
 				temp[size-4]='.';
 			}
-			D(kprintf("Alias new name '%s'\n",temp));
+			D(bug("Alias new name '%s'\n",temp));
 
 			if (node->alias) FreeVecTaskPooled(node->alias);
 			node->alias=(STRPTR)AllocVecTaskPooled(strlen(temp)+1);
@@ -1855,7 +1861,7 @@ DEFSMETHOD(Bookmarkgroup_AddQuickLink)
 			if (qn->obj)
 			{
 				DoMethod(qn->obj, MM_QuickLinkGroup_InitChange, MV_QuickLinkGroup_Change_Add);
-				D(kprintf("Add node to qlgroup %08lx\n", qn->obj));
+				D(bug("Add node to qlgroup %08lx\n", qn->obj));
 				DoMethod(qn->obj, MM_QuickLinkGroup_Add, node);
 				DoMethod(qn->obj, MM_QuickLinkGroup_ExitChange, MV_QuickLinkGroup_Change_Add);
 			}
@@ -1866,7 +1872,7 @@ DEFSMETHOD(Bookmarkgroup_AddQuickLink)
 			obj, 1 | MUIV_PushMethod_Delay(500) | MUIF_PUSHMETHOD_SINGLE,
 			MM_Bookmarkgroup_AutoSave);
 	}
-	D(kprintf("End AddQuickLink\n"));
+	D(bug("End AddQuickLink\n"));
 	return (0);
 }
 
@@ -1901,7 +1907,7 @@ DEFSMETHOD(Bookmarkgroup_RemoveQuickLink)
 	if (node)
 	{
 		APTR n;
-		D(kprintf("Remove QuickLink %ld\n", pos));
+		D(bug("Remove QuickLink %ld\n", pos));
 		node->flags = node->flags & ~NODEFLAG_QUICKLINK;
 
 		DoMethod(data->lt_linklist, MUIM_List_Remove, pos);
@@ -1923,7 +1929,7 @@ DEFSMETHOD(Bookmarkgroup_RemoveQuickLink)
         DoMethod(app, MUIM_Application_PushMethod,
 				obj, 1 | MUIV_PushMethod_Delay(500) | MUIF_PUSHMETHOD_SINGLE,
 				MM_Bookmarkgroup_AutoSave);
-		D(kprintf("Remove QuickLink End\n"));
+		D(bug("Remove QuickLink End\n"));
 	}
 	return (0);
 }
@@ -1932,7 +1938,7 @@ DEFTMETHOD(Bookmarkgroup_DosNotify)
 {
 	GETDATA;
 	// Start reload
-	D(kprintf("DosNotification on bookmarks.html\n"));
+	D(bug("DosNotification on bookmarks.html\n"));
 	// get active for reset after ?
 	set(data->lt_bookmark, MUIA_Listtree_Quiet, TRUE);
 	set(data->lt_linklist, MUIA_List_Quiet, TRUE);
@@ -1965,7 +1971,7 @@ DEFSMETHOD(Bookmarkgroup_RegisterQLGroup)
 
 		DoMethod(qn->obj, MM_QuickLinkGroup_InitChange, MV_QuickLinkGroup_Change_Add);
 
-		D(kprintf("RegisterQLGroup Build QuickLink\n"));
+		D(bug("RegisterQLGroup Build QuickLink\n"));
 		for(pos=0; ; pos++)
 		{
 			if( (tn=(struct MUIS_Listtree_TreeNode *)DoMethod(data->lt_bookmark, MUIM_Listtree_GetEntry, MUIV_Listtree_GetEntry_ListNode_Root, pos, 0)) )
@@ -1974,13 +1980,13 @@ DEFSMETHOD(Bookmarkgroup_RegisterQLGroup)
 				node->treenode = tn;
 				if ( (node) && (node->flags & NODEFLAG_QUICKLINK) )
 				{
-					D(kprintf("Add link\n"));
+					D(bug("Add link\n"));
 					DoMethod(msg->group, MM_QuickLinkGroup_Add, node);
 				}
 			}
 			else break;
 		}
-		D(kprintf("End\n"));
+		D(bug("End\n"));
 		DoMethod(qn->obj, MM_QuickLinkGroup_ExitChange, MV_QuickLinkGroup_Change_Add);
 	}
 	return (0);
@@ -2053,7 +2059,7 @@ DEFMMETHOD(HandleInput)
 					LONG pos=0;
 
 					get(data->win, MUIA_Window_ActiveObject, &active);
-					D(kprintf("Handle %08lx Obj %08lx\n", msg->imsg->Code, active));
+					D(bug("Handle %08lx Obj %08lx\n", msg->imsg->Code, active));
 					if (active==data->st_alias)
 					{
 						if (msg->imsg->Code==0x4d)

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/bookmarklisttreeclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/bookmarklisttreeclass.cpp
@@ -43,6 +43,15 @@
 
 #define LOC(a,b) (b)
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
+
+
 struct Data
 {
 	APTR activetype;
@@ -72,10 +81,10 @@ static void doset(Object *obj, struct Data *data, struct TagItem *tags)
 			if ( (data->drop) && !(data->drop->tn_Flags & TNF_LIST))
 			{
 				Object *window = NULL;
-				//kprintf("Double click open new tab or current ?\n", data->drop);
+				//D(bug("Double click open new tab or current ?\n", data->drop));
 				// Open link
 				td=((struct treedata *)data->drop->tn_User);
-				//kprintf("URL: %s\n", (td->address) ? td->address : (STRPTR)"(NULL)" ); // address can be NULL
+				//D(bug("URL: %s\n", (td->address) ? td->address : (STRPTR)"(NULL)" )); // address can be NULL
 
 				window = (Object *) getv(app, MA_OWBApp_ActiveWindow);
 				if(window)
@@ -96,7 +105,7 @@ MUI_HOOK(bookmarklisttree_constructfunc, APTR pool, APTR t)
 	struct treedata * td;
 	struct treedata * tempnode = (struct treedata *) t;
 
-	//kprintf( "Listtree construct hook title %08lx alias %08lx address %08lx.\n", (ULONG)tempnode->title, (ULONG)tempnode->alias, (ULONG)tempnode->address);
+	//D(bug( "Listtree construct hook title %08lx alias %08lx address %08lx.\n", (ULONG)tempnode->title, (ULONG)tempnode->alias, (ULONG)tempnode->address));
 	if ((td = (struct treedata *) AllocPooled(pool, sizeof(struct treedata))))
 	{
 		td->flags    = tempnode->flags;
@@ -127,7 +136,7 @@ MUI_HOOK(bookmarklisttree_constructfunc, APTR pool, APTR t)
 			if (td->address) strcpy(td->address, tempnode->address);
 		}
 	}
-	//kprintf( "End of construct\n");
+	//D(bug( "End of construct\n"));
 	return (ULONG) (td);
 }
 
@@ -449,28 +458,28 @@ DEFMMETHOD(DragReport)
 							// Don't allow
 							DoMethod(obj, MUIM_Listtree_SetDropMark, r.tpr_ListEntry, MUIV_Listtree_SetDropMark_Values_None);
 							data->drop=NULL;
-							//kprintf("###### Lock\n");
+							//D(bug("###### Lock\n"));
 							return MUIV_DragReport_Lock;
 						}
 						else
 						{
-							//kprintf("###### Draw\n");
+							//D(bug("###### Draw\n"));
 							data->drop = tn;
 							DoMethod(obj, MUIM_Listtree_SetDropMark, r.tpr_ListEntry, r.tpr_Flags);
 						}
 					}
 					else
-					{//kprintf("###### DragReport: no td\n");
+					{//D(bug("###### DragReport: no td\n"));
 					}
 				}
 				else
-				{//kprintf("###### DragReport: not en entry\n");
+				{//D(bug("###### DragReport: not en entry\n"));
 				}
 			}
 		}
 		else
 		{
-			//kprintf("###### DragReport: not en entry\n");
+			//D(bug("###### DragReport: not en entry\n"));
 			//put under
 		}
 	}
@@ -544,7 +553,7 @@ DEFMMETHOD(ContextMenuBuild)
 	struct treedata *td;
 	Object *item;
 
-	//kprintf("Bookmark Context menu build\n");
+	//D(bug("Bookmark Context menu build\n"));
 
 	if (data->cMenu)
 	{
@@ -667,17 +676,17 @@ DEFMMETHOD(ContextMenuChoice)
 	ULONG udata = muiUserData(msg->item);
 	struct treedata *td;
  
-	//kprintf("Bookmark menu trig: %lx\n",udata);
+	//D(bug("Bookmark menu trig: %lx\n",udata));
 	switch (udata)
     {
 		case POPMENU_OPEN_CURRENT:
-			//kprintf("Open link in current view\n");
+			//D(bug("Open link in current view\n"));
 			if (data->drop)	
 			{
 				Object *window;
 
 				td=((struct treedata *)data->drop->tn_User);
-				//kprintf("URL: %s\n", (td->address) ? td->address : (STRPTR)"(NULL)" );
+				//D(bug("URL: %s\n", (td->address) ? td->address : (STRPTR)"(NULL)" ));
 
 				window = (Object *) getv(app, MA_OWBApp_ActiveWindow);
 				if(window)
@@ -687,39 +696,39 @@ DEFMMETHOD(ContextMenuChoice)
 			}
 			break;
 		case POPMENU_OPEN_NEWTAB:
-			//kprintf("Open link in new tab\n");
+			//D(bug("Open link in new tab\n"));
 			if (data->drop)	
 			{
 				td=((struct treedata *)data->drop->tn_User);
-				//kprintf("URL: %s\n", (td->address) ? td->address : (STRPTR)"(NULL)" );
+				//D(bug("URL: %s\n", (td->address) ? td->address : (STRPTR)"(NULL)" ));
 				DoMethod(app, MM_OWBApp_AddBrowser, NULL, td->address, FALSE, NULL, FALSE, FALSE, TRUE);
 			}
 			break;
 		case POPMENU_OPEN_NEWWIN:
-			//kprintf("Open link in new window\n");
+			//D(bug("Open link in new window\n"));
 			if (data->drop)
 			{
 				td=((struct treedata *)data->drop->tn_User);
-				//kprintf("URL: %s\n", (td->address) ? td->address : (STRPTR)"(NULL)" );
+				//D(bug("URL: %s\n", (td->address) ? td->address : (STRPTR)"(NULL)" ));
 				DoMethod(app, MM_OWBApp_AddWindow, td->address, FALSE, NULL, FALSE, NULL, FALSE);
 			}
 			break;
 		case POPMENU_OPEN:
-			//kprintf("Unfold group\n");
+			//D(bug("Unfold group\n"));
 			if (data->drop)	DoMethod(obj, MUIM_Listtree_Open, MUIV_Listtree_Open_ListNode_Root, data->drop, 0);
 			break;
 		case POPMENU_OPEN_ALL:
-			//kprintf("Unfold all group\n");
+			//D(bug("Unfold all group\n"));
 			if (data->drop) DoMethod(obj, MUIM_Listtree_Open, MUIV_Listtree_Open_ListNode_Root, MUIV_Listtree_Open_TreeNode_All, 0);
 			break;
 		case POPMENU_CLOSE:
-			//kprintf("Fold group\n");
+			//D(bug("Fold group\n"));
 			if (data->drop)
 			{
 				if (!(data->drop->tn_Flags & TNF_LIST))
 				{
 					struct MUIS_Listtree_TreeNode *parent=(struct MUIS_Listtree_TreeNode *) DoMethod(obj, MUIM_Listtree_GetEntry, data->drop, MUIV_Listtree_GetEntry_Position_Parent, 0);
-					//kprintf("Parent %08lx\n",parent);
+					//D(bug("Parent %08lx\n",parent));
 					if (parent) DoMethod(obj, MUIM_Listtree_Close, MUIV_Listtree_Close_ListNode_Root, parent, 0);
 				}
 				else
@@ -729,12 +738,12 @@ DEFMMETHOD(ContextMenuChoice)
 			}
 			break;
 		case POPMENU_CLOSE_ALL:
-			//kprintf("Fold all group\n");
+			//D(bug("Fold all group\n"));
 			if (data->drop) DoMethod(obj, MUIM_Listtree_Close, MUIV_Listtree_Close_ListNode_Root, MUIV_Listtree_Close_TreeNode_All, 0);
 			break;
 		default:
 			;
-			//kprintf("Bad Context menu return\n");
+			//D(bug("Bad Context menu return\n"));
     }
 	data->drop=NULL;
     return (ULONG)NULL;

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/bookmarkpanelgroupclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/bookmarkpanelgroupclass.cpp
@@ -43,6 +43,13 @@
 #include <proto/dos.h>
 #include <clib/macros.h>
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
 
 /* private */
 
@@ -104,10 +111,10 @@ static void doset(Object *obj, struct Data *data, struct TagItem *tags)
 			if(active)
 			{
 				current = (struct treedata *)active->tn_User;
-				D(kprintf( "InMenu before is %08lx.\n",(ULONG)current->flags));
+				D(bug( "InMenu before is %08lx.\n",(ULONG)current->flags));
 				if (tag->ti_Data) current->flags = (current->flags & ~NODEFLAG_INMENU) | NODEFLAG_INMENU;
 				else current->flags = current->flags & ~NODEFLAG_INMENU;
-				D(kprintf( "InMenu after is %08lx.\n",(ULONG)current->flags));
+				D(bug( "InMenu after is %08lx.\n",(ULONG)current->flags));
 				line = DoMethod(data->lt_bookmark, MUIM_Listtree_GetNr, active, 0L);
 				DoMethod(data->lt_bookmark, MUIM_List_Redraw, line, NULL);
 			}
@@ -300,7 +307,7 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 			if (p == 3)
 			{
 				q=0;
-				D(kprintf( "Parse Link: '%s'\n", ptr[2]));
+				D(bug( "Parse Link: '%s'\n", ptr[2]));
 
 				if (strcmp(ptr[2],"----------------------------------------")==0)
 				{
@@ -330,7 +337,7 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 				if (q == 2)
 				{
 					// Alias
-					D(kprintf( "    Alias: '%s'\n", ptr[3]));
+					D(bug( "    Alias: '%s'\n", ptr[3]));
 					newnode.alias = ptr[3];
 					p++;
 				}
@@ -340,7 +347,7 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 					q = parsevarpool(ptr[1], "%.OWBQUICKLINK=\"%s\"", &ptr[3]);
 					if (q == 2)
 					{
-						D(kprintf( "QuickLink: '%s'\n", ptr[3]));
+						D(bug( "QuickLink: '%s'\n", ptr[3]));
 						newnode.alias = ptr[3];
 						p++;
 						newnode.flags |= NODEFLAG_QUICKLINK;
@@ -349,11 +356,11 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 						if (q == 2)
 						{
 							newnode.ql_order = order;
-							D(kprintf("Order: %ld\n",order));
+							D(bug("Order: %ld\n",order));
 						}
 						else
 						{
-							D(kprintf("Fail get order '%s'\n", ptr[1]));
+							D(bug("Fail get order '%s'\n", ptr[1]));
 						}
 					}
 					else newnode.alias = NULL;
@@ -362,7 +369,7 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 				q = parsevarpool(ptr[1], "%.IBHLFLAGS=\"%s\"", &ptr[4]);
 				if (q == 2)
 				{
-					D(kprintf( "Flags: '%s'\n", ptr[4]));
+					D(bug( "Flags: '%s'\n", ptr[4]));
 					FreeVecTaskPooled(ptr[4]); ptr[4] = NULL;
 				}
 				else newnode.flags |= NODEFLAG_INMENU;
@@ -385,7 +392,7 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 				p--;
 				if (p == 2)
 				{
-					D(kprintf( "Parse Group: '%s'\n", ptr[1]));
+					D(bug( "Parse Group: '%s'\n", ptr[1]));
 					newnode.flags    = NODEFLAG_GROUP;
 					newnode.title    = ptr[1];
 					newnode.alias    = NULL;
@@ -398,14 +405,14 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 					q = parsevarpool(ptr[0], "%.IBHLFLAGS=\"%s\"", &ptr[4]);
 					if (q == 2)
 					{
-						D(kprintf( "Flags: '%s'\n", ptr[4]));
+						D(bug( "Flags: '%s'\n", ptr[4]));
 						FreeVecTaskPooled(ptr[4]); ptr[4] = NULL;
 					}
 					else newnode.flags |= NODEFLAG_INMENU;
  
 					if (group)
 					{
-						D(kprintf("Only one level of group supported, add group at root\n"));
+						D(bug("Only one level of group supported, add group at root\n"));
 					}
 
 					// Add group
@@ -425,7 +432,7 @@ DEFSMETHOD(Bookmarkgroup_LoadHtml)
 			{
 				if (strstr(line, "</UL>"))
 				{
-					D(kprintf( "Parse End Group\n"));
+					D(bug( "Parse End Group\n"));
 					if(group != NULL)
 					{
 						group = (MUIS_Listtree_TreeNode *) DoMethod(data->lt_bookmark, MUIM_Listtree_GetEntry, group, MUIV_Listtree_GetEntry_Position_Parent, 0);
@@ -460,12 +467,12 @@ DEFSMETHOD(Bookmarkgroup_AddLink)
 	newnode.iconimg  = NULL;
 	newnode.tree     = data->lt_bookmark;
 
-	D(kprintf("AddLink title %s %08lx %08lx\n",msg->title, (ULONG)msg->alias, (ULONG)msg->address));
+	D(bug("AddLink title %s %08lx %08lx\n",msg->title, (ULONG)msg->alias, (ULONG)msg->address));
 
 	if (!msg->external)
 	{
 		active = (struct MUIS_Listtree_TreeNode *) DoMethod(data->lt_bookmark, MUIM_Listtree_GetEntry, NULL, MUIV_Listtree_GetEntry_Position_Active, 0);
-		D(kprintf("Active is %08lx.\n",(ULONG)active));
+		D(bug("Active is %08lx.\n",(ULONG)active));
 	}
 
 	// Disable notifications
@@ -524,7 +531,7 @@ DEFSMETHOD(Bookmarkgroup_AddLink)
 		);
 	}
 
-	D(kprintf( "entry is %08lx.\n",(ULONG)entry));
+	D(bug( "entry is %08lx.\n",(ULONG)entry));
 	set(data->lt_bookmark, MUIA_Listtree_Quiet, FALSE);
 
 	return (0);

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/colorchooserpopupclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/colorchooserpopupclass.cpp
@@ -33,10 +33,14 @@
 #include "ColorChooserController.h"
 
 #include <mui/Calltips_mcc.h>
-#include <clib/debug_protos.h>
 
 #include "gui.h"
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 using namespace WebCore;

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/cookiemanagergroupclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/cookiemanagergroupclass.cpp
@@ -46,6 +46,11 @@
 
 #include "gui.h"
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 using namespace WebCore;
@@ -172,7 +177,7 @@ DEFTMETHOD(CookieManagerGroup_Load)
 
 	DoMethod(data->lt_cookies, MUIM_Listtree_Remove, MUIV_Listtree_Remove_ListNode_Root, MUIV_Listtree_Remove_TreeNode_All, 0);
 
-	D(kprintf("Loading cookies\n"));
+	D(bug("Loading cookies\n"));
 
 	HashMap<String, CookieMap*>& manager_map = cookieManager().getCookieMap();
 
@@ -227,10 +232,10 @@ DEFTMETHOD(CookieManagerGroup_Load)
 		node.http_only = cookie->isHttpOnly();
 		node.session = cookie->isSession();
 
-		D(kprintf("protocol <%s>\n", node.protocol));
-		D(kprintf("\tdomain <%s>\n", node.domain));
-		D(kprintf("\tname <%s>\n", node.name));
-		D(kprintf("\tpath <%s>\n", node.path));
+		D(bug("protocol <%s>\n", node.protocol));
+		D(bug("\tdomain <%s>\n", node.domain));
+		D(bug("\tname <%s>\n", node.name));
+		D(bug("\tpath <%s>\n", node.path));
 
 		/*
 		newentry = (struct MUIS_Listtree_TreeNode *) DoMethod(data->lt_cookies, MUIM_Listtree_FindName,
@@ -279,7 +284,7 @@ DEFSMETHOD(CookieManagerGroup_DidInsert)
 	struct MUIS_Listtree_TreeNode *tn = NULL;
 	ParsedCookie* cookie = (ParsedCookie *) msg->cookie;
 
-	D(kprintf("didInsert <%s><%s>\n", cookie->domain().utf8().data(), cookie->name().utf8().data()));
+	D(bug("didInsert <%s><%s>\n", cookie->domain().utf8().data(), cookie->name().utf8().data()));
 
 	for(pos=0; ; pos++)
 	{
@@ -357,7 +362,7 @@ DEFSMETHOD(CookieManagerGroup_DidRemove)
 	struct MUIS_Listtree_TreeNode *tn = NULL, *tn2 = NULL;
 	ParsedCookie *cookie = (ParsedCookie *) msg->cookie;
 
-	D(kprintf("didRemove <%s><%s>\n", cookie->domain().utf8().data(), cookie->name().utf8().data()));
+	D(bug("didRemove <%s><%s>\n", cookie->domain().utf8().data(), cookie->name().utf8().data()));
 
 	/* find the domain node */
 	for(pos=0; ; pos++)

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/datetimechooserpopupclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/datetimechooserpopupclass.cpp
@@ -35,10 +35,14 @@
 #include "wtf/text/CString.h"
 
 #include <mui/Calltips_mcc.h>
-#include <clib/debug_protos.h>
 
 #include "gui.h"
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 using namespace WebCore;

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/downloadgroupclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/downloadgroupclass.cpp
@@ -43,13 +43,20 @@
 //#include <proto/application.h>
 #include <proto/dos.h>
 
-#include <clib/debug_protos.h>
 #include <clib/macros.h>
 
 #include "gui.h"
 #include "utils.h"
 
 #include <stdio.h>
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
 
 using namespace WebCore;
 
@@ -323,7 +330,7 @@ DEFNEW
 
 	cycles_init();
 
-//	  kprintf("<%s> <%s> <%s>\n", dltitles[PAGE_IN_PROGRESS], dltitles[PAGE_FINISHED], dltitles[PAGE_FAILED]);
+//	  D(bug("<%s> <%s> <%s>\n", dltitles[PAGE_IN_PROGRESS], dltitles[PAGE_FINISHED], dltitles[PAGE_FAILED]));
 
 	obj = (Object *) DoSuperNew(cl, obj,
 			Child, gr_pages = VGroup,

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/downloadlistclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/downloadlistclass.cpp
@@ -47,6 +47,12 @@
 #include "gui.h"
 #include "utils.h"
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 using namespace WebCore;
 
@@ -94,22 +100,22 @@ static void create_icon_if_needed(Object *obj, struct downloadnode *dl, ULONG ty
 
 		if(type == MV_DownloadList_Type_InProgress) // Check against given mimetype
 		{
-			//kprintf ("we in the type == MV_DownloadList_Type_InProgress\n");
+			//D(bug("we in the type == MV_DownloadList_Type_InProgress\n"));
 			if(dl->mimetype)
 			{
-				//kprintf("we in the dl->mimetype\n");				
+				//D(bug("we in the dl->mimetype\n"));
 				String mimetype = dl->mimetype;
 
-				//kprintf ("dl->mimetype is: %s\n", dl->mimetype);
+				//D(bug("dl->mimetype is: %s\n", dl->mimetype));
 				//iconPath = "
 				
 				command = "GetDeficonPath MIMETYPE=\"" + mimetype + "\"";
-				//kprintf("command is = %s\n", command.utf8().data());
+				//D(bug("command is = %s\n", command.utf8().data()));
 				
 				if(rexx_send((char *) "AMBIENT", (char *) command.utf8().data()))
 				{
 					iconPath = String(rexx_result());
-					//kprintf("iconPath in dl->mimetype with x-: %s\n", iconPath.utf8().data());
+					//D(bug("iconPath in dl->mimetype with x-: %s\n", iconPath.utf8().data()));
 				}
 				else // Try again without "x-" prefix, ambient is not always compliant with naming
 				{
@@ -118,7 +124,7 @@ static void create_icon_if_needed(Object *obj, struct downloadnode *dl, ULONG ty
 					if(rexx_send((char *) "AMBIENT", (char *) command.utf8().data()))
 				    {
 						iconPath = String(rexx_result());
-						//kprintf("iconPath in dl->mimetype without x-: %s\n", iconPath.utf8().data());
+						//D(bug("iconPath in dl->mimetype without x-: %s\n", iconPath.utf8().data()));
 					}
 				}
 			}
@@ -129,7 +135,7 @@ static void create_icon_if_needed(Object *obj, struct downloadnode *dl, ULONG ty
 			int len = strlen(dl->filename) + strlen(dl->path) + 2;
 			char *path = (char *) malloc(len);
 
-			//kprintf("we in else and check for the file mimetype\n");
+			//D(bug("we in else and check for the file mimetype\n"));
 			
 			if(path)
 			{
@@ -147,14 +153,14 @@ static void create_icon_if_needed(Object *obj, struct downloadnode *dl, ULONG ty
 					
 					if(lock)
 					{
-						//kprintf("so we in lock!\n");
+						//D(bug("so we in lock!\n"));
 						
 						UnLock(lock);
 						command = "GetDeficonPath PATH=\"" + String(path) + "\"";
 						if(rexx_send((char *) "AMBIENT", (char *) command.utf8().data()))
 					    {
 							iconPath = String(rexx_result());
-							//kprintf("iconPath in lock: %s\n", iconPath.utf8().data());
+							//D(bug("iconPath in lock: %s\n", iconPath.utf8().data()));
 						}
 					}
 
@@ -168,7 +174,7 @@ static void create_icon_if_needed(Object *obj, struct downloadnode *dl, ULONG ty
 		if((type == MV_DownloadList_Type_InProgress && dl->mimetype) || type != MV_DownloadList_Type_InProgress)
 		{
 		
-			//kprintf(" we in the type == MV_DownloadList_Type_InProgress && dl->mimetype) || type != MV_DownloadList_Type_InProgress\n");
+			//D(bug(" we in the type == MV_DownloadList_Type_InProgress && dl->mimetype) || type != MV_DownloadList_Type_InProgress\n"));
 						
 			dl->iconobj  = NewObject(geticonclass(), NULL,
 								    MA_Icon_Path, iconPath.utf8().data(),
@@ -177,7 +183,7 @@ static void create_icon_if_needed(Object *obj, struct downloadnode *dl, ULONG ty
 			
 			
 
-			//kprintf("final MA_Icon_Path is: %s\n", iconPath.utf8().data());
+			//D(bug("final MA_Icon_Path is: %s\n", iconPath.utf8().data()));
 			
 			if(dl->iconobj)
 			{

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/faviconclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/faviconclass.cpp
@@ -43,16 +43,21 @@
 #include <proto/alib.h>
 #include <proto/cybergraphics.h>
 #include <proto/utility.h>
-#include <clib/debug_protos.h>
 
 #include "gui.h"
-
-#define D(x)
 
 #define FAVICON_WIDTH 16
 #define FAVICON_HEIGHT 16
 
 #define FACTOR (data->scalefactor + 1)
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
 
 using namespace WebCore;
 
@@ -93,7 +98,7 @@ STATIC VOID doset(struct Data *data, APTR obj, struct TagItem *taglist)
 
 			case MA_FavIcon_NeedRedraw:
 			{
-				D(kprintf("Setting MA_FavIcon_NeedRedraw for <%s>\n", data->url, tag_data));
+				D(bug("Setting MA_FavIcon_NeedRedraw for <%s>\n", data->url, tag_data));
 				data->need_redraw = tag_data;
 			}
 			break;

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/gui.h
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/gui.h
@@ -4,7 +4,6 @@
 #include <exec/types.h>
 #include <proto/utility.h>
 #include <utility/date.h>
-#include <clib/debug_protos.h>
 
 #include "classes.h"
 #include "methodstack.h"

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/iconclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/iconclass.cpp
@@ -43,10 +43,14 @@
 #include <proto/alib.h>
 #include <proto/cybergraphics.h>
 #include <proto/utility.h>
-#include <clib/debug_protos.h>
 
 #include "gui.h"
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 #define ICON_WIDTH 22

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/linklistclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/linklistclass.cpp
@@ -42,6 +42,14 @@
 
 #define LOC(a,b) (b)
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
+
 struct Data
 {
 	LONG    Drop;
@@ -62,9 +70,9 @@ static void doset(Object *obj, struct Data *data, struct TagItem *tags)
 			DoMethod(obj, MUIM_List_GetEntry, MUIV_List_GetEntry_Active, &td);
 			if (td)
 			{
-				//kprintf("Double click on %08lx\n", td);
+				//D(bug("Double click on %08lx\n", td));
 				// Open link
-				//kprintf("URL: %s\n", (td->alias) ? td->alias : (STRPTR)"(NULL)" ); // address can be NULL
+				//D(bug("URL: %s\n", (td->alias) ? td->alias : (STRPTR)"(NULL)" )); // address can be NULL
 			}
 			break;
 		case MA_Bookmarkgroup_BookmarkObject:
@@ -228,18 +236,18 @@ DEFMMETHOD(DragQuery)
 	
 	if( (data->bookmark_list) && msg->obj==data->bookmark_list)
 	{
-		//kprintf("From Bookmark\n");
+		//D(bug("From Bookmark\n"));
 		tn=(struct MUIS_Listtree_TreeNode *)DoMethod(msg->obj, MUIM_Listtree_GetEntry, NULL, MUIV_Listtree_GetEntry_Position_Active, 0);
 		if (tn)
 		{
 			td=(struct treedata *)tn->tn_User;
-			//kprintf("Flags: %08lx\n",td->flags);
+			//D(bug("Flags: %08lx\n",td->flags));
 			if ( (td->flags & NODEFLAG_LINK) && !(td->flags & NODEFLAG_QUICKLINK) && !(td->flags & NODEFLAG_BAR) ) return MUIV_DragQuery_Accept;
 		}
 	}
 	if( msg->obj==obj )
 	{
-		//kprintf("From ourself\n");
+		//D(bug("From ourself\n"));
 		return MUIV_DragQuery_Accept;
 	}
 
@@ -260,7 +268,7 @@ DEFMMETHOD(DragReport)
 			data->Drop=r.entry;
 			data->Drop_Pos=r.flags;
 			data->Drop_Offset=r.yoffset;
-			//kprintf("DropEntry is %ld pos %ld yoffset %ld\n", data->Drop, data->Drop_Pos, r.yoffset);
+			//D(bug("DropEntry is %ld pos %ld yoffset %ld\n", data->Drop, data->Drop_Pos, r.yoffset));
 		}
 	}
 	return DOSUPER;
@@ -274,7 +282,7 @@ DEFMMETHOD(DragDrop)
 	if (msg->obj==data->bookmark_list)
 	{
 		// From Bookmark
-		//kprintf("Drop from Bookmark\n");
+		//D(bug("Drop from Bookmark\n"));
 		rc=data->Drop+1;
 		if (data->Drop_Pos==1) rc=1;
 		if (data->Drop_Pos==2) rc=-1;
@@ -282,7 +290,7 @@ DEFMMETHOD(DragDrop)
 		set(data->bookmark_obj, MA_Bookmarkgroup_QuickLink, rc);
 		return 0;
 	}
-	//kprintf("Drop sort\n");
+	//D(bug("Drop sort\n"));
 	rc=DOSUPER;
 	DoMethod(app, MUIM_Application_PushMethod,
 		data->bookmark_obj, 1 | MUIV_PushMethod_Delay(500) | MUIF_PUSHMETHOD_SINGLE,

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/methodstack.c
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/methodstack.c
@@ -30,6 +30,11 @@
 
 #include <stdarg.h>
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 STATIC struct SignalSemaphore semaphore;
@@ -135,7 +140,7 @@ void methodstack_check(void)
 {
 	ULONG not_empty = TRUE;
 
-	//D(kprintf("[MethodStack] methodstack_check()\n"));
+	//D(bug("[MethodStack] methodstack_check()\n"));
 
 	do
 	{

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/owbbrowserclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/owbbrowserclass.cpp
@@ -129,7 +129,14 @@ extern "C"
 #include "gui.h"
 #include "utils.h"
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
+
+
 
 extern CONST_STRPTR * get_user_agent_strings();
 
@@ -486,7 +493,7 @@ DEFNEW
 		/* Passed attributes */
 		set(obj, MA_OWBBrowser_PrivateBrowsing, (ULONG) GetTagData(MA_OWBBrowser_PrivateBrowsing, FALSE, msg->ops_AttrList));
 
-		//kprintf("OWBBrowser: loading url <%s> is_frame: %d sourceview %p\n", data->url, data->is_frame, data->source_view);
+		//D(bug("OWBBrowser: loading url <%s> is_frame: %d sourceview %p\n", data->url, data->is_frame, data->source_view));
 
 		if(data->source_view)
 		{
@@ -1408,7 +1415,7 @@ DEFMMETHOD(Show)
 
 	rc = DOSUPER;
 
-	D(kprintf("[OWBBrowser] Show: %p size: %dx%d at (%d,%d) for widget %p\n", obj, _mwidth(obj), _mheight(obj), _mleft(obj), _mtop(obj), data->view));
+	D(bug("[OWBBrowser] Show: %p size: %dx%d at (%d,%d) for widget %p\n", obj, _mwidth(obj), _mheight(obj), _mleft(obj), _mtop(obj), data->view));
 
 	ULONG oldwidth = data->width;
 	ULONG oldheight = data->height;
@@ -1443,7 +1450,7 @@ DEFMMETHOD(Show)
 	// Window size changed
 	if(oldwidth != data->width || oldheight != data->height)
 	{
-		D(kprintf("[OWBBrowser] Resizing\n"));
+		D(bug("[OWBBrowser] Resizing\n"));
 
 #if USE_MORPHOS_SURFACE
 		struct Window *window = (struct Window *) getv(data->view->window, MUIA_Window);
@@ -1490,7 +1497,7 @@ DEFMMETHOD(Show)
 			if(window && data->video_handle)
 			{
 				IntSize size = data->video_element->player()->naturalSize();
-				//kprintf("naturalsize %dx%d\n", size.width(), size.height());
+				//D(bug("naturalsize %dx%d\n", size.width(), size.height()));
 
 				if ( ( (float) size.width() / (float) size.height()) < ( (float) _mwidth(obj) / (float) _mheight(obj)) )
 				{
@@ -1643,7 +1650,7 @@ DEFSMETHOD(OWBBrowser_Update)
 		}
 	}
 
-	//kprintf("[update] %f ms\n", (currentTime() - start)*1000);
+	//D(bug("[update] %f ms\n", (currentTime() - start)*1000));
 
 	return 0;
 }
@@ -1669,7 +1676,7 @@ DEFSMETHOD(OWBBrowser_Scroll)
 
     data->pendingscrollrect = data->scrollrect;
 
-	//kprintf("[scroll] %f ms\n", (currentTime() - start)*1000);
+	//D(bug("[scroll] %f ms\n", (currentTime() - start)*1000));
 
 	return 0;
 }
@@ -1688,7 +1695,7 @@ DEFMMETHOD(Draw)
 
 	if (msg->flags & MADF_DRAWUPDATE)
 	{
-		D(kprintf("[OWBBrowser] Drawupdate\n"));
+		D(bug("[OWBBrowser] Drawupdate\n"));
 
 		if(data->draw_mode == DRAW_UPDATE)
 		{
@@ -1722,7 +1729,7 @@ DEFMMETHOD(Draw)
 			stride = data->plugin_stride;
 			src	= data->plugin_src;
 
-			D(kprintf("draw plugin: %dx%d at (%d, %d) src 0x%p stride %lu\n", data->update_width, data->update_height, data->update_x, data->update_y, src, stride));
+			D(bug("draw plugin: %dx%d at (%d, %d) src 0x%p stride %lu\n", data->update_width, data->update_height, data->update_x, data->update_y, src, stride));
 
 #if USE_MORPHOS_SURFACE
 			// XXX: implement
@@ -1742,7 +1749,7 @@ DEFMMETHOD(Draw)
 	}
 	else if(msg->flags & MADF_DRAWOBJECT)
 	{
-		D(kprintf("[OWBBrowser] Drawobject\n"));
+		D(bug("[OWBBrowser] Drawobject\n"));
 
 #if USE_MORPHOS_SURFACE
 		BltBitMapRastPort(cairo_morphos_surface_get_bitmap(data->view->surface), 0, 0, _rp(obj), _mleft(obj), _mtop(obj), _mwidth(obj), _mheight(obj), 0xCC);
@@ -2482,7 +2489,7 @@ DEFMMETHOD(GoActive)
 {
 	/*
 	GETDATA;
-	kprintf("GoActive\n");
+	D(bug("GoActive\n"));
 	data->is_active = TRUE;
 	data->view->webView->updateFocusedAndActiveState();
 	_flags(obj) &= ~MADF_KNOWSACTIVE;
@@ -2494,7 +2501,7 @@ DEFMMETHOD(GoInactive)
 {
 	/*
 	GETDATA;
-	kprintf("GoInactive\n");
+	D(bug("GoInactive\n"));
 	data->is_active = FALSE;
 	data->view->webView->updateFocusedAndActiveState();
 	*/
@@ -2506,7 +2513,7 @@ DEFTMETHOD(OWBBrowser_FocusChanged)
 	/*
 	GETDATA;
 	data->is_active = ((Object *) getv(_win(obj), MUIA_Window_ActiveObject)) == obj;
-	kprintf("FocusChanged: activeobject %d\n", ((Object *) getv(_win(obj), MUIA_Window_ActiveObject)) == obj);
+	D(bug("FocusChanged: activeobject %d\n", ((Object *) getv(_win(obj), MUIA_Window_ActiveObject)) == obj));
 	*/
 
 	return 0;
@@ -3484,7 +3491,7 @@ DEFMMETHOD(DragQuery)
 {
 	GETDATA;
 
-	D(kprintf("DragQuery from %p for %p\n", msg->obj, obj));
+	D(bug("DragQuery from %p for %p\n", msg->obj, obj));
 
 	LONG type = getv(msg->obj, MA_OWB_ObjectType);
 
@@ -3493,7 +3500,7 @@ DEFMMETHOD(DragQuery)
 	{
 		if(type == MV_OWB_ObjectType_Browser)
 		{
-			D(kprintf("Source object is a browser dataObject %p\n", dataObject));
+			D(bug("Source object is a browser dataObject %p\n", dataObject));
 			if(obj != msg->obj)
 			{
 				dataObject = (APTR) getv(msg->obj, MA_OWBBrowser_DragData);
@@ -3514,13 +3521,13 @@ DEFMMETHOD(DragBegin)
 {
 	GETDATA;
 
-	D(kprintf("DragBegin (%d %d)\n", data->last_position.x(), data->last_position.y()));
+	D(bug("DragBegin (%d %d)\n", data->last_position.x(), data->last_position.y()));
 
 	if(dataObject)
 	{
 		IntPoint position(data->last_position);
 		DragData dragData((DataObjectMorphOS *) dataObject, position, position, (DragOperation) data->dragoperation);
-		D(kprintf("dragEntered\n"));
+		D(bug("dragEntered\n"));
 		/*DragOperation operation = */core(data->view->webView)->dragController().dragEntered(&dragData);
 	}
 
@@ -3531,7 +3538,7 @@ DEFMMETHOD(DragReport)
 {
 	GETDATA;
 
-	//D(kprintf("DragReport (%d %d)\n", msg->x - _mleft(obj), msg->y - _mtop(obj)));
+	//D(bug("DragReport (%d %d)\n", msg->x - _mleft(obj), msg->y - _mtop(obj)));
 
 	if(!msg->update)
 	{
@@ -3543,7 +3550,7 @@ DEFMMETHOD(DragReport)
 		IntPoint position(msg->x - _mleft(obj), msg->y - _mtop(obj));
 		data->last_drag_position = position;
 		DragData dragData((DataObjectMorphOS *) dataObject, position, position, (DragOperation) data->dragoperation);
-		//D(kprintf("dragUpdated\n"));
+		//D(bug("dragUpdated\n"));
 		/*DragOperation operation = */core(data->view->webView)->dragController().dragUpdated(&dragData);
 	}
 
@@ -3554,7 +3561,7 @@ DEFMMETHOD(DragFinish)
 {
 	GETDATA;
 
-	D(kprintf("DragFinish (%d %d) dropfollows %d\n", data->last_drag_position.x(), data->last_drag_position.y(), msg->dropfollows));
+	D(bug("DragFinish (%d %d) dropfollows %d\n", data->last_drag_position.x(), data->last_drag_position.y(), msg->dropfollows));
 
 	if(dataObject)
 	{
@@ -3563,7 +3570,7 @@ DEFMMETHOD(DragFinish)
 		{
 			IntPoint position(data->last_drag_position);
 			DragData dragData((DataObjectMorphOS *) dataObject, position, position, (DragOperation) data->dragoperation);
-			D(kprintf("dragExited\n"));
+			D(bug("dragExited\n"));
 			core(data->view->webView)->dragController().dragExited(&dragData);
 		}
 
@@ -3577,7 +3584,7 @@ DEFMMETHOD(DragDrop)
 {
 	GETDATA;
 
-	D(kprintf("DragDrop drop (%d %d) last_drag_position (%d %d)\n", msg->x - _mleft(obj), msg->y - _mtop(obj), data->last_drag_position.x(), data->last_drag_position.y())); // Wrong pos, why?
+	D(bug("DragDrop drop (%d %d) last_drag_position (%d %d)\n", msg->x - _mleft(obj), msg->y - _mtop(obj), data->last_drag_position.x(), data->last_drag_position.y())); // Wrong pos, why?
 
 	if(dataObject)
 	{
@@ -3595,16 +3602,16 @@ DEFMMETHOD(DragDrop)
 			event.Code  = IECODE_LBUTTON | IECODE_UP_PREFIX;
 
 			PlatformMouseEvent pevent = PlatformMouseEvent(&event);
-			D(kprintf("dragSourceEndedAt(%d %d)\n", position.x(), position.y()));
+			D(bug("dragSourceEndedAt(%d %d)\n", position.x(), position.y()));
 			frame->eventHandler().dragSourceEndedAt(pevent, (DragOperation) data->dragoperation);
 		}
 
 		// Perform the drag
 		data->last_drag_position = position;
 		DragData dragData((DataObjectMorphOS *) dataObject, position, position, (DragOperation) data->dragoperation);
-		D(kprintf("performDrag\n"));
+		D(bug("performDrag\n"));
 		core(data->view->webView)->dragController().performDrag(&dragData);
-		//D(kprintf("dragEnded\n"));
+		//D(bug("dragEnded\n"));
 		//core(data->view->webView)->dragController()->dragEnded();
 		//dataObject = 0;
 	}
@@ -3691,7 +3698,7 @@ DEFMMETHOD(Backfill)
 	struct Rectangle b1, b2, k;
 	struct Rectangle bounds = { left, top, right, bottom };
 
-//	  kprintf("backfill %d %d %d %d x_offset %d y_offset %d\n", left, top, right, bottom, mygui->x_offset, mygui->y_offset);
+//	  D(bug("backfill %d %d %d %d x_offset %d y_offset %d\n", left, top, right, bottom, mygui->x_offset, mygui->y_offset));
 
 	/* key rect */
 	k.MinX = left + data->video_x_offset;
@@ -3812,7 +3819,7 @@ DEFSMETHOD(OWBBrowser_VideoEnterFullPage)
 			if(window)
 			{
 				IntSize size = element->player()->naturalSize();
-				//kprintf("naturalsize %dx%d\n", size.width(), size.height());
+				//D(bug("naturalsize %dx%d\n", size.width(), size.height()));
 
 				ULONG vlayer_width  = size.width() & -8;
 				ULONG vlayer_height = size.height() & -2;
@@ -3959,7 +3966,7 @@ DEFSMETHOD(OWBBrowser_VideoBlit)
 {
 	GETDATA;
 
-	//kprintf("blitoverlay %d %d %d\n", msg->width, msg->height, msg->linesize);
+	//D(bug("blitoverlay %d %d %d\n", msg->width, msg->height, msg->linesize));
 
 	if(data->video_handle && msg->src && msg->stride && LockVLayer(data->video_handle))
 	{
@@ -4093,7 +4100,7 @@ DEFSMETHOD(Plugin_RenderRastPort)
 		PluginRect *nprect = (PluginRect *) msg->rect;
 		IntRect rect(nprect->x + npwindowrect->x, nprect->y + npwindowrect->y, nprect->width, nprect->height);
 
-		D(kprintf("RenderRastPort rect [%d, %d, %d, %d] windowrect [%d, %d, %d, %d] src 0x%p stride %lu\n",
+		D(bug("RenderRastPort rect [%d, %d, %d, %d] windowrect [%d, %d, %d, %d] src 0x%p stride %lu\n",
 				 nprect->x, nprect->y, nprect->width, nprect->height,
 				 npwindowrect->x, npwindowrect->y, npwindowrect->width, npwindowrect->height,
 				 msg->src, msg->stride));
@@ -4110,7 +4117,7 @@ DEFSMETHOD(Plugin_RenderRastPort)
 		PluginRect *npwindowrect = (PluginRect *) msg->windowrect;
 		IntRect windowrect(npwindowrect->x, npwindowrect->y, npwindowrect->width, npwindowrect->height);
 
-		D(kprintf("RenderRastPort rect [%d, %d, %d, %d] windowrect [%d, %d, %d, %d] src 0x%p stride %lu\n",
+		D(bug("RenderRastPort rect [%d, %d, %d, %d] windowrect [%d, %d, %d, %d] src 0x%p stride %lu\n",
 				 nprect->x, nprect->y, nprect->width, nprect->height,
 				 npwindowrect->x, npwindowrect->y, npwindowrect->width, npwindowrect->height,
 				 msg->src, msg->stride));
@@ -4212,7 +4219,7 @@ DEFTMETHOD(Plugin_IsBrowserActive)
 {
 	ULONG ret = FALSE;
 
-	D(kprintf("IsBrowserActive\n"));
+	D(bug("IsBrowserActive\n"));
 
 	if(muiRenderInfo(obj) && _win(obj) && getv(app, MA_OWBApp_ShouldAnimate))
 	{
@@ -4230,7 +4237,7 @@ DEFSMETHOD(Plugin_AddIDCMPHandler)
 	GETDATA;
 	struct EventHandlerNode *n;
 
-	D(kprintf("Plugin_AddIDCMPHandler %p %p\n", msg->instance, msg->handlerfunc));
+	D(bug("Plugin_AddIDCMPHandler %p %p\n", msg->instance, msg->handlerfunc));
 
 	n = (struct EventHandlerNode *) malloc(sizeof(*n));
 
@@ -4250,7 +4257,7 @@ DEFSMETHOD(Plugin_RemoveIDCMPHandler)
 	GETDATA;
 	APTR n, m;
 
-	D(kprintf("Plugin_RemoveIDCMPHandler %p\n", msg->instance));
+	D(bug("Plugin_RemoveIDCMPHandler %p\n", msg->instance));
 
 	ITERATELISTSAFE(n, m, &data->eventhandlerlist)
 	{

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/owbwindowclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/owbwindowclass.cpp
@@ -82,6 +82,13 @@
 #include "clipboard.h"
 #include "asl.h"
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
 /******************************************************************
  * owbwindowclass
  *****************************************************************/
@@ -219,7 +226,7 @@ static void copyWebViewSelectionToClipboard(WebView* webView, bool html, bool lo
 
 static  void setup_browser_notifications(Object *obj, struct Data *data, Object *browser)
 {
-	//kprintf("OWBWindow: setup notifications for browser %p\n", browser);
+	//D(bug("OWBWindow: setup notifications for browser %p\n", browser));
 
 	DoMethod(browser, MUIM_Notify, MA_OWBBrowser_Loading, MUIV_EveryTime, data->progressgroup,   3, MUIM_Set, MUIA_Group_ActivePage, MUIV_TriggerValue);
 	DoMethod(browser, MUIM_Notify, MA_OWBBrowser_Loading, MUIV_EveryTime, data->navigationgroup, 3, MUIM_Set, MA_TransferAnim_Animate, MUIV_TriggerValue);
@@ -242,7 +249,7 @@ static  void setup_browser_notifications(Object *obj, struct Data *data, Object 
 
 	/*
 	Object *urlstring = (Object *) getv((Object *) getv(data->addressbargroup, MA_AddressBarGroup_PopString), MUIA_Popstring_String);
-	kprintf("set notification urlstring %p browser %p\n", urlstring, browser);
+	D(bug("set notification urlstring %p browser %p\n", urlstring, browser));
 	DoMethod(urlstring, MUIM_Notify, MUIA_String_Contents, MUIV_EveryTime, browser, 3, MUIM_Set, MA_OWBBrowser_EditedURL, MUIV_TriggerValue);
 	*/
 	//DoMethod(obj, MUIM_Notify, MUIA_Window_ActiveObject, MUIV_EveryTime, browser, 1, MM_OWBBrowser_FocusChanged);
@@ -252,10 +259,10 @@ static void cleanup_browser_notifications(Object *obj, struct Data *data, Object
 {
 	//DoMethod(obj, MUIM_KillNotify, MUIA_Window_ActiveObject);
 
-	//kprintf("OWBWindow: cleanup notifications for browser %p\n", browser);
+	//D(bug("OWBWindow: cleanup notifications for browser %p\n", browser));
 	/*
 	Object *urlstring = (Object *) getv((Object *) getv(data->addressbargroup, MA_AddressBarGroup_PopString), MUIA_Popstring_String);
-	kprintf("clear notification urlstring %p browser %p\n", urlstring, browser);
+	D(bug("clear notification urlstring %p browser %p\n", urlstring, browser));
 	DoMethod(urlstring, MUIM_KillNotifyObj, MUIA_String_Contents, browser);
 	*/
 	DoMethod(browser, MUIM_KillNotify, MA_OWBBrowser_Loading);
@@ -572,7 +579,7 @@ DEFDISP
 	GETDATA;
 	APTR n, m;
 
-	//kprintf("OWBWindow: disposing window %p\n", obj);
+	//D(bug("OWBWindow: disposing window %p\n", obj));
 
 	if(data->completion_thread)
 	{
@@ -613,7 +620,7 @@ DEFDISP
 
 	free(data->userscriptimage_shorthelp);
 
-	//kprintf("OWBWindow: ok, calling supermethod\n");
+	//D(bug("OWBWindow: ok, calling supermethod\n"));
 
 	return DOSUPER;
 }
@@ -2308,7 +2315,7 @@ DEFSMETHOD(OWBWindow_ActivePage)
 
 	data->lastpagenum = msg->pagenum;
 
-	//kprintf("OWBWindow: active page %d\n", msg->pagenum);
+	//D(bug("OWBWindow: active page %d\n", msg->pagenum));
 
 	FORCHILD(data->pagegroup, MUIA_Group_ChildList)
 	{
@@ -2332,8 +2339,8 @@ DEFSMETHOD(OWBWindow_ActivePage)
 
 			data->active_browser = (Object *) getv((Object *)child, MA_OWBGroup_Browser);
 
-			//kprintf("OWBWindow: active browser = %p\n", data->active_browser);
-			//kprintf("OWBWindow: loading state: %d\n", getv(data->active_browser, MA_OWBBrowser_Loading));
+			//D(bug("OWBWindow: active browser = %p\n", data->active_browser));
+			//D(bug("OWBWindow: loading state: %d\n", getv(data->active_browser, MA_OWBBrowser_Loading)));
 
 			setup_browser_notifications(obj, data, data->active_browser);
 

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/printerwindowclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/printerwindowclass.cpp
@@ -41,8 +41,14 @@
 #include "OWBPrintContext.h"
 #include "gui.h"
 
-#define D(x)
 #define USE_THREAD 0
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 using namespace WebCore;
 
@@ -477,16 +483,16 @@ DEFTMETHOD(PrinterWindow_Start)
 							Catalog *catalog = pctx->doc->getCatalog();
 							pctx->cairo_dev->startDoc(pctx->doc->getXRef(), catalog);
 
-							kprintf("PrinterName = '%s', Version=%u, Revision=%u\n",
+							D(bug("PrinterName = '%s', Version=%u, Revision=%u\n",
 							   PD->pd_SegmentData->ps_PED.ped_PrinterName, PD->pd_SegmentData->ps_Version,
-							   PD->pd_SegmentData->ps_Revision);
-						   kprintf("PrinterClass=%u, ColorClass=%u\n",
-							   PD->pd_SegmentData->ps_PED.ped_PrinterClass, PD->pd_SegmentData->ps_PED.ped_ColorClass);
-						   kprintf("MaxColumns=%u, NumCharSets=%u, NumRows=%u\n",
-							   PD->pd_SegmentData->ps_PED.ped_MaxColumns, PD->pd_SegmentData->ps_PED.ped_NumCharSets, PD->pd_SegmentData->ps_PED.ped_NumRows);
-						   kprintf("MaxXDots=%lu, MaxYDots=%lu, XDotsInch=%u, YDotsInch=%u\n",
+							   PD->pd_SegmentData->ps_Revision));
+							D(bug("PrinterClass=%u, ColorClass=%u\n",
+							   PD->pd_SegmentData->ps_PED.ped_PrinterClass, PD->pd_SegmentData->ps_PED.ped_ColorClass));
+							D(bug("MaxColumns=%u, NumCharSets=%u, NumRows=%u\n",
+							   PD->pd_SegmentData->ps_PED.ped_MaxColumns, PD->pd_SegmentData->ps_PED.ped_NumCharSets, PD->pd_SegmentData->ps_PED.ped_NumRows));
+							D(bug("MaxXDots=%lu, MaxYDots=%lu, XDotsInch=%u, YDotsInch=%u\n",
 							   PD->pd_SegmentData->ps_PED.ped_MaxXDots, PD->pd_SegmentData->ps_PED.ped_MaxYDots,
-							   PD->pd_SegmentData->ps_PED.ped_XDotsInch, PD->pd_SegmentData->ps_PED.ped_YDotsInch);
+							   PD->pd_SegmentData->ps_PED.ped_XDotsInch, PD->pd_SegmentData->ps_PED.ped_YDotsInch));
 
 
 							struct RastPort MyRastPort;
@@ -499,11 +505,11 @@ DEFTMETHOD(PrinterWindow_Start)
 							int width = round((pdfpage->getMediaWidth()/72.0)*25.4)*dpi_x/25.4;
 							int height = round((pdfpage->getMediaHeight()/72.0)*25.4)*dpi_y/25.4;
 
-							//kprintf("CairoOutputDev init ok: %d %d\n", 4960, 7015);
+							//D(bug("CairoOutputDev init ok: %d %d\n", 4960, 7015));
 
 							_cairo_surface *surface = cairo_image_surface_create(CAIRO_FORMAT_RGB24, width, height);
 
-							//kprintf("cairo_image_surface_create init ok\n");
+							//D(bug("cairo_image_surface_create init ok\n"));
 							pctx->cairo = cairo_create(pctx->surface);
 							cairo_save(pctx->cairo);
 							cairo_set_source_rgb(pctx->cairo,  1., 1., 1);
@@ -511,9 +517,9 @@ DEFTMETHOD(PrinterWindow_Start)
 							cairo_restore(pctx->cairo);
 							pctx->cairo_dev->setCairo(pctx->cairo);
 
-							//kprintf(" setCairo ok\n");
+							//D(bug(" setCairo ok\n"));
 							pctx->doc->displayPage(pctx->cairo_dev, page, dpi_x, dpi_y, 0, gTrue, gFalse, gTrue);
-							//kprintf(" displayPage ok\n");
+							//D(bug(" displayPage ok\n"));
 
 							InitRastPort(&MyRastPort);
 							MyRastPort.BitMap = &MyBitMap;

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/quicklinkbuttongroupclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/quicklinkbuttongroupclass.cpp
@@ -41,9 +41,14 @@
 #include "gui.h"
 #include "bookmarkgroupclass.h"
 
-#define D(x)
-
 #define LOC(a,b) b
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 struct Data
 {
@@ -226,7 +231,7 @@ DEFNEW
 		data->cMenu = tmp.cMenu;
 		data->mode = tmp.mode;
 		data->cMenu_Title[0] = '\0';
-		//kprintf("QuickLinkButtonGroup End\n");
+		//D(bug("QuickLinkButtonGroup End\n"));
 
 		if(data->node->flags & NODEFLAG_GROUP)
 		{
@@ -685,7 +690,7 @@ DEFTMETHOD(QuickLinkButtonGroup_Redraw)
 
 	if(muiRenderInfo(obj))
 	{
-		D(kprintf("QuickLinkButtonGroup_Redraw <%s>\n", data->node->address));
+		D(bug("QuickLinkButtonGroup_Redraw <%s>\n", data->node->address));
 		MUI_Redraw(obj, MADF_DRAWOBJECT);
 
 		if(data->icon)
@@ -703,7 +708,7 @@ DEFSMETHOD(QuickLinkButtonGroup_RedrawMenuItem)
 
 	if(data->pMenu)
 	{
-		D(kprintf("QuickLinkButtonGroup_RedrawMenu\n"));
+		D(bug("QuickLinkButtonGroup_RedrawMenu\n"));
 		MUI_Redraw((Object *) msg->obj, MADF_DRAWOBJECT);
 	}
 

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/quicklinkgroupclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/quicklinkgroupclass.cpp
@@ -40,6 +40,11 @@
 #define get(obj,attr,store) GetAttr(attr,obj,(ULONG *)store)
 #endif
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 /* private */
@@ -86,7 +91,7 @@ static void doset(Object *obj, struct Data *data, struct TagItem *tags)
 					APTR cstate;
 					Object *child;
 					
-					D(kprintf("QuickLinkGroup Set Mode\n"));
+					D(bug("QuickLinkGroup Set Mode\n"));
 					
 					get(obj,MUIA_Group_ChildList,&l);
 					cstate=l->mlh_Head;
@@ -136,7 +141,7 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 			
 			get(obj, MA_QuickLinkGroup_Data, &data);
 	
-			D(kprintf("### QuickLinkGroup MinMax Data: %08lx:\n",(ULONG)data));
+			D(bug("### QuickLinkGroup MinMax Data: %08lx:\n",(ULONG)data));
 			if (!data) return(FALSE);    
 
 			//get(obj, MUIA_Group_HorizSpacing, &data->hspace);
@@ -148,14 +153,14 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 			data->count=0;
 			//data->truerow=data->row;
 
-			//kprintf("Start calculate hspace=%ld vspace=%ld\n",data->hspace,data->vspace);
+			//D(bug("Start calculate hspace=%ld vspace=%ld\n",data->hspace,data->vspace));
 			cstate = (Object *)lm->lm_Children->mlh_Head;
 			while ( (child=(Object *)NextObject(&cstate)) )
 			{
 				data->count++;
 				if (_minwidth(child)>minwidth)  minwidth=_minwidth(child);
 				if (_minheight(child)>minheight) minheight=_minheight(child);
-				D(kprintf("mw=%ld dw=%ld\n",_minwidth(child),_defwidth(child));)
+				D(bug("mw=%ld dw=%ld\n",_minwidth(child),_defwidth(child));)
 			}
 
 			// Store size mini of a button like a grid
@@ -177,7 +182,7 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 				maxheight=(minheight*data->truerow)+(data->vspace*(data->truerow-1));
 			}
 
-			//D(kprintf("Group: min size is w=%ld h=%ld\n",minwidth,minheight));
+			//D(bug("Group: min size is w=%ld h=%ld\n",minwidth,minheight));
 
 			/* set the result fields in the message */
 			if (data->mode & MV_QuickLinkGroup_Mode_Vert)
@@ -202,7 +207,7 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 			data->max_h=lm->lm_MinMax.MaxHeight;
 			data->max_w=lm->lm_MinMax.MaxWidth;
  
-			D(kprintf("Layout MinMax END.\n"));
+			D(bug("Layout MinMax END.\n"));
 			return(0);
 		}
 
@@ -232,9 +237,9 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 			
 			get(obj, MA_QuickLinkGroup_Data, &data);
 			
-			D(kprintf("### QuickLinkGroup Layout Data: %08lx:\n",(ULONG)data));
+			D(bug("### QuickLinkGroup Layout Data: %08lx:\n",(ULONG)data));
 			if (!data) return(FALSE);    
-			//D(kprintf("Layout Width=%ld Button_w=%ld Hspace=%ld\n", lm->lm_Layout.Width, data->button_w, data->hspace));
+			//D(bug("Layout Width=%ld Button_w=%ld Hspace=%ld\n", lm->lm_Layout.Width, data->button_w, data->hspace));
 
 			if (data->mode & MV_QuickLinkGroup_Mode_Vert)
 			{
@@ -250,7 +255,7 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 					ULONG last_col=(lm->lm_Layout.Width) / (data->button_w + data->hspace);  
 					cols=data->count/data->row;  // Want n cols per line   	
 					if (data->count%data->row>0) cols++;   
-					D(kprintf("Layout can display %ld and want %ld\n",last_col,cols);)
+					D(bug("Layout can display %ld and want %ld\n",last_col,cols);)
 					
 					if (last_col>cols)
 					{
@@ -258,14 +263,14 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 						array_x= (lm->lm_Layout.Width) / cols;
 						if ((array_x*cols)+(data->hspace*(cols-1)>lm->lm_Layout.Width)) array_x--;   
 						if ((array_x*cols)+(data->hspace*(cols-1)>lm->lm_Layout.Width)) array_x--;
-						D(kprintf("Col Mode 1: cols=%ld array_x=%ld\n",cols,array_x);)
+						D(bug("Col Mode 1: cols=%ld array_x=%ld\n",cols,array_x);)
 					}
 					else
 					{
 						array_x= (lm->lm_Layout.Width) / last_col; 	 
 						if ((array_x*last_col)+(data->hspace*(last_col-1)>lm->lm_Layout.Width)) array_x--;
 						if ((array_x*last_col)+(data->hspace*(last_col-1)>lm->lm_Layout.Width)) array_x--;    
-						D(kprintf("Col Mode 2: last_col=%ld array_x=%ld\n",last_col,array_x);)
+						D(bug("Col Mode 2: last_col=%ld array_x=%ld\n",last_col,array_x);)
 					}
 					/*if (lm->lm_Layout.Width/cols > array_x)
 					{
@@ -286,7 +291,7 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 					if ((array_x*cols)+(data->hspace*(cols-1)>lm->lm_Layout.Width)) array_x--;
 				}
 			}
-			//D(kprintf("Layout cols=%ld array_x=%ld array_y=%ld\n", cols, array_x, array_y));
+			//D(bug("Layout cols=%ld array_x=%ld array_y=%ld\n", cols, array_x, array_y));
 			xpos=0;
 			ypos=0;
 			col_count=1;
@@ -322,7 +327,7 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 							}
 							if (!MUI_Layout(child,xpos,ypos,temp_w,_minheight(child),0))
 							{
-								D(kprintf("Layout fail for: child=%08lx x=%ld y=%ld w=%ld h=%ld\n",child,xpos,ypos,array_x,array_y));
+								D(bug("Layout fail for: child=%08lx x=%ld y=%ld w=%ld h=%ld\n",child,xpos,ypos,array_x,array_y));
 								return(FALSE);
 							}
 							if (data->mode & MV_QuickLinkGroup_Mode_Vert) ypos+=data->vspace+_minheight(child);
@@ -332,7 +337,7 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 					}
 				}
 				max_row=row_count;
-				D(kprintf("Prop MaxRow is %ld Truerow is %ld\n", max_row, data->truerow)); 	
+				D(bug("Prop MaxRow is %ld Truerow is %ld\n", max_row, data->truerow)); 	
 			}
 			else
 			{
@@ -344,7 +349,7 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 					{
 						ULONG pos=node->ql_order;
 						pos--;
-						//D(kprintf("Order %ld xpos=%ld ypos=%ld\n", pos, pos%cols, pos/cols));
+						//D(bug("Order %ld xpos=%ld ypos=%ld\n", pos, pos%cols, pos/cols));
 						if (data->mode & MV_QuickLinkGroup_Mode_Vert)  
 						{
 							row_count=pos%cols;
@@ -361,7 +366,7 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 								row_count=pos/cols;
 								xpos=col_count*(array_x+data->hspace);
 								ypos=row_count*(array_y+data->vspace);
-								D(kprintf("Want %ld x %ld\n",col_count, row_count);)
+								D(bug("Want %ld x %ld\n",col_count, row_count);)
 								if (xpos+array_x>lm->lm_Layout.Width)
 								{
 									// no more space for this button add it under  	
@@ -369,7 +374,7 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 									ULONG warp_col=col_count-last_col;
 									col_count=(warp_col%last_col);
 									row_count+=data->row+data->row*(warp_col/last_col);
-									D(kprintf("-> Recalc %ld x %ld\n",col_count, row_count);)
+									D(bug("-> Recalc %ld x %ld\n",col_count, row_count);)
 									xpos=col_count*(array_x+data->hspace);
 									ypos=row_count*(array_y+data->vspace);
 								}
@@ -385,16 +390,16 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 								if (row_count>max_row) max_row=row_count;  	
 							}
 						}
-						//D(kprintf("Layout: x=%ld y=%ld x+=%ld y+=%ld\n", xpos, ypos, xpos+array_x, ypos+array_y ));
+						//D(bug("Layout: x=%ld y=%ld x+=%ld y+=%ld\n", xpos, ypos, xpos+array_x, ypos+array_y ));
 						if (array_x<data->button_w)
 						{
-							D(kprintf("################# BUG ##############\n");)
-							D(kprintf("Array X < minbut delta is %ld (space avail %ld)\n",data->button_w-array_x,data->hspace);)
+							D(bug("################# BUG ##############\n");)
+							D(bug("Array X < minbut delta is %ld (space avail %ld)\n",data->button_w-array_x,data->hspace);)
 							if (data->button_w-array_x<=data->hspace) array_x+=data->button_w-array_x;
 						}
 						if (!MUI_Layout(child,xpos,ypos,array_x,array_y,0))
 						{
-							D(kprintf("Layout fail for: child=%08lx x=%ld y=%ld w=%ld h=%ld\n",child,xpos,ypos,array_x,array_y));
+							D(bug("Layout fail for: child=%08lx x=%ld y=%ld w=%ld h=%ld\n",child,xpos,ypos,array_x,array_y));
 							return(FALSE);
 						}
 					}
@@ -408,14 +413,14 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 			{
 				lm->lm_Layout.Height=((max_row+1)*array_y)+(data->vspace*max_row);
 			}
-			D(kprintf("Layout END.\n"));
+			D(bug("Layout END.\n"));
 			max_row++;
-			D(kprintf("Relayout: max_row=%ld truerow=%ld initial=%ld\n", max_row, data->truerow, data->row));
+			D(bug("Relayout: max_row=%ld truerow=%ld initial=%ld\n", max_row, data->truerow, data->row));
 			if (data->re_layout_count<2)
 			{
 				if (max_row>data->truerow && data->truerow<data->row )
 				{
-					D(kprintf("Relayout: Need more max_row=%ld truerow=%ld initial=%ld ", max_row, data->truerow, data->row));
+					D(bug("Relayout: Need more max_row=%ld truerow=%ld initial=%ld ", max_row, data->truerow, data->row));
 					if (max_row>data->row)
 					{
 						data->truerow=data->row;
@@ -423,7 +428,7 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 					}
 					else data->truerow=max_row;
 					
-					D(kprintf("-> truerow=%ld\n", data->truerow));
+					D(bug("-> truerow=%ld\n", data->truerow));
 					data->re_layout_count++;
 					/*
 					DoMethod(app, MUIM_Application_PushMethod,
@@ -449,10 +454,10 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 				}
 				if (max_row<data->truerow && data->truerow>1)
 				{
-					D(kprintf("Relayout: Need less max_row=%ld truerow=%ld initial=%ld ", max_row, data->truerow, data->row));
+					D(bug("Relayout: Need less max_row=%ld truerow=%ld initial=%ld ", max_row, data->truerow, data->row));
 					if (max_row==2 && data->row==1) data->truerow=2;
 					else data->truerow=max_row;
-					D(kprintf("-> truerow=%ld\n", data->truerow));
+					D(bug("-> truerow=%ld\n", data->truerow));
 					data->re_layout_count++;
 					/*DoMethod(app, MUIM_Application_PushMethod,
 						obj, 1,
@@ -473,7 +478,7 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 			}
 			else
 			{
-				D(kprintf("############## Relayout bug try fix\n"));
+				D(bug("############## Relayout bug try fix\n"));
 			}
 			data->re_layout_count=0;
 			return(TRUE);
@@ -532,7 +537,7 @@ DEFNEW
 DEFDISP
 {
 	GETDATA;
-	D(kprintf("QuickLinkGroup: disposing\n"));
+	D(bug("QuickLinkGroup: disposing\n"));
 	return DOSUPER;
 }
 
@@ -548,7 +553,7 @@ DEFGET
 		}
 		case MA_QuickLinkGroup_Mode:
 		{
-			D(kprintf("QLGroup Get Mode=%08lx\n",data->mode));
+			D(bug("QLGroup Get Mode=%08lx\n",data->mode));
 			*msg->opg_Storage = data->mode;
 			return (TRUE);
 		}
@@ -675,7 +680,7 @@ DEFSMETHOD(QuickLinkGroup_Remove)
 	APTR           cstate;
 	APTR child;
 	
-	D(kprintf("QuickLinkGroup_Remove\n"));
+	D(bug("QuickLinkGroup_Remove\n"));
 
 	get(obj,MUIA_Group_ChildList,&l);
 	cstate=l->mlh_Head;
@@ -684,10 +689,10 @@ DEFSMETHOD(QuickLinkGroup_Remove)
 	{
 		node=NULL;
 		get((Object *)child, MUIA_UserData, &node);
-		//kprintf("Button %08lx %08lx\n", msg->td, node);
+		//D(bug("Button %08lx %08lx\n", msg->td, node));
 		if (node==msg->td)
 		{
-			D(kprintf("Found %s\n",node->alias));
+			D(bug("Found %s\n",node->alias));
 			DoMethod(obj, OM_REMMEMBER, child);
 			// add break here;
 			DoMethod((Object *)child, OM_DISPOSE);
@@ -706,7 +711,7 @@ DEFSMETHOD(QuickLinkGroup_Update)
 	APTR cstate;
 	Object *child;
 	
-	D(kprintf("QuickLinkGroup_Update\n"));
+	D(bug("QuickLinkGroup_Update\n"));
 	
 	get(obj,MUIA_Group_ChildList,&l);
 	cstate=l->mlh_Head;
@@ -717,7 +722,7 @@ DEFSMETHOD(QuickLinkGroup_Update)
 		get(child, MUIA_UserData, &node);
 		if (node==msg->td)
 		{
-			D(kprintf("Found %s\n",node->alias));
+			D(bug("Found %s\n",node->alias));
 			DoMethod(obj,   MUIM_Group_InitChange);
 			DoMethod(child, MM_QuickLinkButtonGroup_Update);
 			DoMethod(obj,   MUIM_Group_ExitChange);

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/quicklinkparentgroupclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/quicklinkparentgroupclass.cpp
@@ -40,7 +40,12 @@
 #define get(obj,attr,store) GetAttr(attr,obj,(ULONG *)store)
 #endif
 
-//#define D(x)
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 /* private */
 
@@ -74,7 +79,7 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 					get(child, MA_QuickLinkGroup_MinH, &min_h);
 					get(child, MA_QuickLinkGroup_MaxW, &max_w);
 					get(child, MA_QuickLinkGroup_MaxH, &max_h);
-					D(kprintf("QL Parent Group: mode=%ld buts=%ld min_w=%ld min_h=%ld\n",mode,buts,min_w,min_h));
+					D(bug("QL Parent Group: mode=%ld buts=%ld min_w=%ld min_h=%ld\n",mode,buts,min_w,min_h));
 					if (mode & MV_QuickLinkGroup_Mode_Vert)
 					{
 						lm->lm_MinMax.MinWidth  = max_w;
@@ -96,7 +101,7 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 				}
 				else
 				{
-					D(kprintf("QL Parent Group: HIDED\n"));
+					D(bug("QL Parent Group: HIDED\n"));
 					if (_maxheight(child)==1)
 					{
 						// HSpace()
@@ -135,7 +140,7 @@ static ULONG LayoutFonc( struct Hook *hook, Object *obj, struct MUI_LayoutMsg *l
 					h=_maxheight(child);
 					if (w>lm->lm_Layout.Width) w=lm->lm_Layout.Width;
 					if (h>lm->lm_Layout.Height) h=lm->lm_Layout.Height;
-					D(kprintf("QL Parent Group: w=%ld h=%ld\n",w,h));
+					D(bug("QL Parent Group: w=%ld h=%ld\n",w,h));
 					if (!MUI_Layout(child,0,0,w,h,0))
 					{
 						return(FALSE);
@@ -220,18 +225,18 @@ static void doset(Object *obj, struct Data *data, struct TagItem *tags)
 					Object *button;
 					struct MinList *l;
 					APTR cstate;
-					D(kprintf("QuickLinkParentGroup_Hide FALSE\n"));
+					D(bug("QuickLinkParentGroup_Hide FALSE\n"));
 					get(obj, MUIA_Group_ChildList, &l);
 					cstate=l->mlh_Head;
 					button=(Object *)NextObject((Object **)&cstate);
 					//DoMethod(obj, MUIM_Group_InitChange);
 					if (button)
 					{
-						D(kprintf("QuickLinkParentGroup_Hide Remove space\n"));
+						D(bug("QuickLinkParentGroup_Hide Remove space\n"));
 						DoMethod(obj, OM_REMMEMBER, button);
 						DoMethod(button, OM_DISPOSE);
 					}
-					D(kprintf("QuickLinkParentGroup_Hide Add QLGroup %08lx\n", data->qlgroup));
+					D(bug("QuickLinkParentGroup_Hide Add QLGroup %08lx\n", data->qlgroup));
 					DoMethod(obj, OM_ADDMEMBER, data->qlgroup);
 					//DoMethod(obj, MUIM_Group_ExitChange);
 					data->hidden=FALSE;
@@ -244,12 +249,12 @@ static void doset(Object *obj, struct Data *data, struct TagItem *tags)
 					struct MinList *l;
 					APTR cstate;
 
-					D(kprintf("QuickLinkParentGroup_Hide TRUE\n"));
+					D(bug("QuickLinkParentGroup_Hide TRUE\n"));
 					get(obj, MUIA_Group_ChildList, &l);
 					cstate=l->mlh_Head;
 					data->qlgroup=(Object *)NextObject((Object **)&cstate);
 					//DoMethod(obj, MUIM_Group_InitChange);
-					D(kprintf("QuickLinkParentGroup_Hide Remove QLGroup %08lx\n", data->qlgroup));
+					D(bug("QuickLinkParentGroup_Hide Remove QLGroup %08lx\n", data->qlgroup));
 					if (data->qlgroup)
 					{
 						DoMethod(obj, OM_REMMEMBER, data->qlgroup);
@@ -259,14 +264,14 @@ static void doset(Object *obj, struct Data *data, struct TagItem *tags)
 					if (mode & MV_QuickLinkGroup_Mode_Vert)
 					{
 						// Vertical mode add 1 pixel band
-						D(kprintf("QuickLinkParentGroup_Hide Add HSpace\n"));
+						D(bug("QuickLinkParentGroup_Hide Add HSpace\n"));
 						child=(Object *)HSpace(1);
 						if(child) DoMethod(obj, MUIM_Group_AddTail, child);
 					}
 					else
 					{
 						// Horiz mode add 1 pixel band
-						D(kprintf("QuickLinkParentGroup_Hide Add VSpace\n"));
+						D(bug("QuickLinkParentGroup_Hide Add VSpace\n"));
 						child=(Object *)VSpace(1);
 						if(child) DoMethod(obj, MUIM_Group_AddTail, child);
 					}
@@ -299,10 +304,10 @@ DEFNEW
 DEFDISP
 {
 	GETDATA;
-	D(kprintf("QuickLinkParentGroup: disposing\n"));
+	D(bug("QuickLinkParentGroup: disposing\n"));
 	if (data->hidden)
 	{
-		D(kprintf("Hidden mode dispose QLGroup"));
+		D(bug("Hidden mode dispose QLGroup"));
 		DoMethod(data->qlgroup, OM_DISPOSE);
 	}
 	return DOSUPER;

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/splashwindowclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/splashwindowclass.cpp
@@ -45,7 +45,6 @@ extern "C"
 #include <proto/dos.h>
 #include <proto/intuition.h>
 #include <proto/utility.h>
-#include <clib/debug_protos.h>
 
 #include "gui.h"
 #include "utils.h"
@@ -69,6 +68,13 @@ struct  MUIP_Process_Launch                 { ULONG MethodID; };
 #else
 #define USE_SHARED_FONTCONFIG 1
 #endif
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 using namespace WebCore;
 
@@ -107,7 +113,7 @@ void fontconfig_testcache(void)
 
     signal(SIGINT, SIG_IGN);
 
-    //kprintf("[fontcache thread] doing stuff\n");
+    //D(bug("[fontcache thread] doing stuff\n"));
 
 #if !USE_SHARED_FONTCONFIG
     fontconfig_progress_callback = myfontconfig_progress_callback;
@@ -120,7 +126,7 @@ void fontconfig_testcache(void)
 		return;
     }
 
-    //kprintf("[fontcache thread] still doing stuff\n");
+    //D(bug("[fontcache thread] still doing stuff\n"));
 
     pat = FcNameParse ((FcChar8 *) ":");
     os = FcObjectSetBuild (FC_FAMILY, FC_STYLE, (char *) 0);
@@ -134,13 +140,13 @@ void fontconfig_testcache(void)
 		// We should fail here
 	}
 
-	//kprintf("[fontcache thread] always doing stuff\n");
+	//D(bug("[fontcache thread] always doing stuff\n"));
 
     if (fs)
     {
 		int	j;
 
-		//kprintf("[fontcache thread] fs->nfont %d\n", fs->nfont);
+		//D(bug("[fontcache thread] fs->nfont %d\n", fs->nfont));
 
 		for (j = 0; j < fs->nfont; j++)
 		{
@@ -150,7 +156,7 @@ void fontconfig_testcache(void)
 			{
 				APTR n;
 
-				//kprintf("[fontcache thread] font file <%s>\n", file);
+				//D(bug("[fontcache thread] font file <%s>\n", file));
 
 				ITERATELIST(n, &family_list)
 				{
@@ -182,7 +188,7 @@ void fontconfig_testcache(void)
 	FcExtRemoveProgressCallback((FcExtProgressCallback)myfontconfig_progress_callback);
 #endif
 
-	//kprintf("[fontcache thread] done\n");
+	//D(bug("[fontcache thread] done\n"));
 }
 
 DEFNEW
@@ -222,7 +228,7 @@ DEFNEW
 	{
 		GETDATA;
 
-		//kprintf("[splashwindow] OM_NEW\n");
+		//D(bug("[splashwindow] OM_NEW\n"));
 
 		g_splash = obj;
 		data->maintask = FindTask(NULL);
@@ -235,7 +241,7 @@ DEFNEW
 					MUIA_Process_AutoLaunch  , FALSE,
 					TAG_DONE);
 
-		//kprintf("[splashwindow] proc = %p\n", data->proc);
+		//D(bug("[splashwindow] proc = %p\n", data->proc));
 	}
 
 	return (IPTR)obj;
@@ -262,7 +268,7 @@ DEFTMETHOD(SplashWindow_Open)
 		return 0;
 	}
 
-	//kprintf("[splashwindow] running fontcache thread %p\n", data->proc);
+	//D(bug("[splashwindow] running fontcache thread %p\n", data->proc));
 
 	if((data->StartupBit = AllocSignal(-1)) != -1)
 	{
@@ -270,7 +276,7 @@ DEFTMETHOD(SplashWindow_Open)
 		{
 			Wait(1L<<data->StartupBit);
 
-			//kprintf("[splashwindow] splashwindow loop\n");
+			//D(bug("[splashwindow] splashwindow loop\n"));
 
 			for(;data->running;)
 			{
@@ -296,7 +302,7 @@ DEFTMETHOD(SplashWindow_Open)
 
 	set(obj, MUIA_Window_Open, FALSE);
 
-	//kprintf("[splashwindow] quitting loop\n");
+	//D(bug("[splashwindow] quitting loop\n"));
 
 	return 0;
 }
@@ -318,7 +324,7 @@ DEFMMETHOD(Process_Process)
 {
 	GETDATA;
 
-	//kprintf("[fontcache thread] running indexation\n");
+	//D(bug("[fontcache thread] running indexation\n"));
 
 	struct Process *myproc = (struct Process *)FindTask(NULL);
 	APTR oldwindowptr = myproc->pr_WindowPtr;
@@ -335,7 +341,7 @@ DEFMMETHOD(Process_Process)
 
 	fontconfig_testcache();
 
-	//kprintf("[fontcache thread] signaling thread end to main task\n");
+	//D(bug("[fontcache thread] signaling thread end to main task\n"));
 
 	myproc->pr_WindowPtr = oldwindowptr;
 

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/titlelabelclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/titlelabelclass.cpp
@@ -33,10 +33,14 @@
 
 #include <clib/macros.h>
 #include <proto/dos.h>
-#include <clib/debug_protos.h>
 
 #include "gui.h"
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 /******************************************************************
@@ -372,7 +376,7 @@ DEFTMETHOD(Title_Redraw)
 
 	if(muiRenderInfo(obj))
 	{
-		D(kprintf("Title_Redraw <%s>\n", (STRPTR) getv(browser, MA_OWBBrowser_URL)));
+		D(bug("Title_Redraw <%s>\n", (STRPTR) getv(browser, MA_OWBBrowser_URL)));
 
 		MUI_Redraw(obj, MADF_DRAWOBJECT);
 

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/toolbutton_addbookmarkclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/toolbutton_addbookmarkclass.cpp
@@ -29,10 +29,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <clib/debug_protos.h>
 
 #include "gui.h"
-
 
 struct Data
 {

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/toolbutton_bookmarksclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/toolbutton_bookmarksclass.cpp
@@ -29,10 +29,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <clib/debug_protos.h>
 
 #include "gui.h"
-
 
 struct Data
 {

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/toolbutton_newtabclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/toolbutton_newtabclass.cpp
@@ -28,10 +28,8 @@
 
 #include <string.h>
 #include <stdio.h>
-#include <clib/debug_protos.h>
 
 #include "gui.h"
-
 
 struct Data
 {

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/toolbuttonclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/toolbuttonclass.cpp
@@ -29,7 +29,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <devices/rawkeycodes.h>
-#include <clib/debug_protos.h>
 
 #include "gui.h"
 

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/urlprefsgroupclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/urlprefsgroupclass.cpp
@@ -48,6 +48,13 @@
 #define get(obj,attr,store) GetAttr(attr,obj,(ULONG *)store)
 #endif
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
 extern STRPTR * get_user_agent_strings();
 extern STRPTR * get_user_agent_labels();
 
@@ -454,7 +461,7 @@ DEFSMETHOD(URLPrefsGroup_ApplySettingsForURL)
 	WebView *webView = (WebView *) msg->webView;
 	BalWidget *widget = webView->viewWindow();
 
-	//kprintf("ApplySettingForURL <%s>\n", msg->url);
+	//D(bug("ApplySettingForURL <%s>\n", msg->url));
 
 	if(webView && widget)
 	{
@@ -501,7 +508,7 @@ DEFSMETHOD(URLPrefsGroup_ApplySettingsForURL)
 
 			if(re.match(msg->url) >=0)
 			{
-				//kprintf("ApplySettingForURL pattern <%s> matches\n", un->urlpattern);
+				//D(bug("ApplySettingForURL pattern <%s> matches\n", un->urlpattern));
 
 				// Apply URL settings
 				webView->page()->settings().setScriptEnabled(un->settings.javascript != FALSE);

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/urlstringclass.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/urlstringclass.cpp
@@ -34,7 +34,6 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <clib/debug_protos.h>
 
 #include "gui.h"
 

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/utils.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/MorphOS/utils.cpp
@@ -62,6 +62,12 @@
 #include "aos4funcs_api.h"
 #endif
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 using namespace WebCore;
 
@@ -562,7 +568,7 @@ STRPTR get_accepted_languages(STRPTR code, ULONG len)
 	
 	STRPTR ret = NULL;
 
-	//kprintf("get_accpeted_languages(): at begining\n");
+	//D(bug("get_accpeted_languages(): at begining\n"));
 	
 	if(l)
 	{
@@ -571,13 +577,13 @@ STRPTR get_accepted_languages(STRPTR code, ULONG len)
 		code[0] = 0;
 		ret = code;
 
-		//kprintf("get_accpeted_languages(): in if(l)\n");
+		//D(bug("get_accpeted_languages(): in if(l)\n"));
 		
 		for(i=0; l->loc_PrefLanguages[i] && i < 10; i++)
 		{
 			char *ptr;
 
-			//kprintf("get_accpeted_languages(): in if(l->locl_PrefLanguages))\n");
+			//D(bug("get_accpeted_languages(): in if(l->locl_PrefLanguages))\n"));
 			
 			ptr = (char *) getcode(l->loc_PrefLanguages[i]);
 
@@ -621,8 +627,8 @@ STRPTR get_accepted_languages(STRPTR code, ULONG len)
 		CloseLocale(l);
 	}
 
-	//kprintf("get_accepted_languages: ret is: %s\n", ret);
-	//kprintf("get_accepted_languages: code is: %s\n", code);
+	//D(bug("get_accepted_languages: ret is: %s\n", ret));
+	//D(bug("get_accepted_languages: code is: %s\n", code));
 
 	return ret;
 }
@@ -633,15 +639,15 @@ STRPTR get_language(STRPTR code, ULONG len)
 	struct Locale *l = OpenLocale(NULL);
 	STRPTR ret = NULL;
 
-	//kprintf("get_language(): at begining\n");
+	//D(bug("get_language(): at begining\n"));
 	
 	if(l)
 	{
-		//kprintf("get_language(): in if(l)\n");		
+		//D(bug("get_language(): in if(l)\n"));
 		if((l->loc_PrefLanguages[0]) && (getcode(l->loc_PrefLanguages[0]) != NULL))
 		{
 		
-			//kprintf("get_language(): in l->loc_PrefLangauges[0] && getcode blablabl\n");
+			//D(bug("get_language(): in l->loc_PrefLangauges[0] && getcode blablabl\n"));
 			ret = code;
 			stccpy(code, (char *) getcode(l->loc_PrefLanguages[0]), len);
 			
@@ -652,13 +658,13 @@ STRPTR get_language(STRPTR code, ULONG len)
 
 	if(!ret)
 	{
-		//kprintf("get_language(): aha, we in fail and return !ret\n");
+		//D(bug("get_language(): aha, we in fail and return !ret\n"));
 		ret = code;
 		stccpy(code, "en", len);
 	}
 
-	//kprintf("get_language: ret is: %s\n", ret);
-	//kprintf("get_language: code is: %s\n", code);
+	//D(bug("get_language: ret is: %s\n", ret));
+	//D(bug("get_language: code is: %s\n", code));
 	return ret;
 }
 
@@ -970,8 +976,8 @@ void enable_blanker(struct Screen *screen, ULONG enable)
 
 			if(screen)
 			{
-				//kprintf("%s blanker\n", enable ? "Enabling" : "Disabling" );
-				SetAttrs(screen, SA_StopBlanker, enable ? FALSE : TRUE, TAG_DONE);				  
+				//D(bug("%s blanker\n", enable ? "Enabling" : "Disabling" ));
+				SetAttrs(screen, SA_StopBlanker, enable ? FALSE : TRUE, TAG_DONE);
 			}
 		}
 	}

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebDownload.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebDownload.cpp
@@ -56,8 +56,14 @@
 
 #if OS(MORPHOS)
 #include "gui.h"
-#include <clib/debug_protos.h>
 #endif
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 using namespace WebCore;
 
@@ -183,7 +189,7 @@ void DownloadClient::didReceiveResponse(ResourceHandle*, const WebCore::Resource
 		// If we're here, it means resume wasn't supported after all
 		if(priv->resourceHandle.get()->isResuming()) 
 		{
-			kprintf("Wanted to resume, but can't\n");
+			D(bug("Wanted to resume, but can't\n"));
 			priv->allowResume = false;
 			priv->allowOverwrite = true; // discuss that
 		}
@@ -451,7 +457,7 @@ void WebDownload::start(bool quiet)
 		m_priv->quiet = getv(app, MA_OWBApp_DownloadStartAutomatically);
 	}
 
-	//kprintf("quiet %d\n", m_priv->quiet);
+	//D(bug("quiet %d\n", m_priv->quiet));
 
     if (m_priv->resourceHandle)
     {

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebDownloadDelegate.h
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebDownloadDelegate.h
@@ -41,7 +41,6 @@
 #include "SharedObject.h"
 #include "WebKitTypes.h"
 #include <set>
-#include <clib/debug_protos.h>
 
 class WebError;
 class WebDownload;

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebHistory.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebHistory.cpp
@@ -44,10 +44,16 @@
 
 #if OS(MORPHOS)
 #include "gui.h"
-#include <clib/debug_protos.h>
 #undef String
 #undef PageGroup
 #endif
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 #include <stdio.h>
 
@@ -317,7 +323,7 @@ void WebHistory::removeAllItems()
 
 WebHistoryItem* WebHistory::itemForURL(const char* url)
 {
-	//kprintf("WebHistory::itemForURL(%s)\n", url.latin1().data());
+	//D(bug("WebHistory::itemForURL(%s)\n", url.latin1().data()));
 
 	for(unsigned int i=0; i < m_historyList.size(); i++)
 	{
@@ -445,7 +451,7 @@ void WebHistory::addVisitedLinksToPageGroup(PageGroup& group)
 
 WebHistoryItem* WebHistory::itemForURLString(const char* urlString) const
 {
-	//kprintf("WebHistory::itemForURLString(%s)\n", urlString.latin1().data());
+	//D(bug("WebHistory::itemForURLString(%s)\n", urlString.latin1().data()));
 	free((char *)urlString);
     return 0;
 }

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebHistoryItem.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebHistoryItem.cpp
@@ -33,8 +33,6 @@
 #include <WTFString.h>
 #include <HistoryItem.h>
 
-#include <clib/debug_protos.h>
-
 using namespace WebCore;
 
 static HashMap<HistoryItem*, WebHistoryItem*>& historyItemWrappers()

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebIconDatabase.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebIconDatabase.cpp
@@ -49,9 +49,14 @@
 #undef get
 #undef String
 #undef PageGroup
-#include <clib/debug_protos.h>
-#define D(x)
 #endif
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 using namespace WebCore;
 using namespace WTF;
@@ -273,7 +278,7 @@ void WebIconDatabase::didRemoveAllIcons()
 
 void WebIconDatabase::didImportIconURLForPageURL(const char* pageURL)
 {   
-	D(kprintf("WebIconDatabase::didImportIconURLForPageURL(%s)\n", pageURL));
+	D(bug("WebIconDatabase::didImportIconURLForPageURL(%s)\n", pageURL));
 
     MutexLocker locker(m_webIconDatabaseClient->m_notificationMutex);
     m_notificationQueue.push_back(String(pageURL));
@@ -284,14 +289,14 @@ void WebIconDatabase::didImportIconURLForPageURL(const char* pageURL)
 
 void WebIconDatabase::didImportIconDataForPageURL(const char* pageURL)
 {
-	D(kprintf("WebIconDatabase::didImportIconDataForPageURL(%s)\n", pageURL));
+	D(bug("WebIconDatabase::didImportIconDataForPageURL(%s)\n", pageURL));
     // WebKit1 only has a single "icon did change" notification.
     didImportIconURLForPageURL(pageURL);
 }
 
 void WebIconDatabase::didChangeIconForPageURL(const char* pageURL)
 {
-	D(kprintf("WebIconDatabase::didChangeIconForPageURL(%s)\n", pageURL));
+	D(bug("WebIconDatabase::didChangeIconForPageURL(%s)\n", pageURL));
     // WebKit1 only has a single "icon did change" notification.
     didImportIconURLForPageURL(pageURL);
 }
@@ -339,7 +344,7 @@ static void postDidAddIconNotification(String pageURL, WebIconDatabase* iconDB)
 {
 #if OS(MORPHOS)
 	SetAttrs(app, MA_OWBApp_DidReceiveFavIcon, pageURL.utf8().data(), TAG_DONE);
-	D(kprintf("postDidAddIconNotification(%s)\n", pageURL.utf8().data()));
+	D(bug("postDidAddIconNotification(%s)\n", pageURL.utf8().data()));
 #endif
     WebCore::ObserverServiceData::createObserverService()->notifyObserver(WebIconDatabase::iconDatabaseDidAddIconNotification(), pageURL, iconDB);
 }
@@ -377,7 +382,7 @@ bool operator<(BalPoint p1, BalPoint p2)
 #if OS(MORPHOS)
 void WebIconDatabase::didFinishURLIconImport()
 {
-	D(kprintf("WebIconDatabase::didFinishURLIconImport()\n"));
+	D(bug("WebIconDatabase::didFinishURLIconImport()\n"));
 	SetAttrs(app, MA_OWBApp_FavIconImportComplete, TRUE, TAG_DONE);
 	//allowDatabaseCleanup();
 }

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebResource.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebResource.cpp
@@ -30,7 +30,12 @@
 #include "WebResource.h"
 
 #include <WTFString.h>
-#include <clib/debug_protos.h>
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 using namespace WebCore;
 
@@ -55,7 +60,7 @@ WebResource* WebResource::createInstance(PassRefPtr<WebCore::SharedBuffer> data,
 
 void WebResource::initWithData( PassRefPtr<WebCore::SharedBuffer> data, String url, String mimeType, String textEncodingName, String frameName)
 {
-    kprintf("WebResource::initWithData\n");
+    D(bug("WebResource::initWithData\n"));
     m_data = data;
     m_url = KURL(ParsedURLString, String(url));
     m_mimeType = String(mimeType);

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebView.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/Api/WebView.cpp
@@ -177,6 +177,13 @@
 #undef PageGroup
 #endif
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
+
 using namespace WebCore;
 using std::min;
 using std::max;
@@ -204,7 +211,7 @@ public:
 
     virtual void call()
     {
-    	kprintf("dispatchNotEnoughMemory\n");
+    	D(bug("dispatchNotEnoughMemory\n"));
 		morphos_crash(0);
     }
 };
@@ -675,13 +682,13 @@ void WebView::close()
 
 void WebView::repaint(const WebCore::IntRect& windowRect, bool contentChanged, bool immediate, bool repaintContentOnly)
 {
-    //kprintf("WebView::repaint([%d %d %d %d], %d, %d , %d\n", windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), contentChanged, immediate, repaintContentOnly);
+    //D(bug("WebView::repaint([%d %d %d %d], %d, %d , %d\n", windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), contentChanged, immediate, repaintContentOnly));
     d->repaint(windowRect, contentChanged, immediate, repaintContentOnly);
 }
 
 void WebView::deleteBackingStore()
 {
-    //kprintf("WebView::deleteBackingStore\n");
+    //D(bug("WebView::deleteBackingStore\n"));
     if (m_deleteBackingStoreTimerActive) {
         m_deleteBackingStoreTimerActive = false;
     }
@@ -711,13 +718,13 @@ void WebView::clearDirtyRegion()
 
 void WebView::scrollBackingStore(FrameView* frameView, int dx, int dy, const BalRectangle& scrollViewRect, const BalRectangle& clipRect)
 {
-    //kprintf("WebView::scrollBackingStore\n");
+    //D(bug("WebView::scrollBackingStore\n"));
     d->scrollBackingStore(frameView, dx, dy, scrollViewRect, clipRect);
 }
 
 void WebView::updateBackingStore(FrameView* frameView, bool backingStoreCompletelyDirty)
 {
-    //kprintf("WebView::updateBackingStore(completelyDirty %d\n", backingStoreCompletelyDirty);
+    //D(bug("WebView::updateBackingStore(completelyDirty %d\n", backingStoreCompletelyDirty));
     //frameView->updateBackingStore();
 }
 
@@ -1144,7 +1151,7 @@ bool WebView::canShowMIMEType(const char* mimeType)
 	|| m_page->pluginData().supportsMimeType(type, PluginData::OnlyApplicationPlugins);
     }     
     
-    //kprintf("WebView::canShowMIMEType(%s): %s\n", type.utf8().data(), canShow ? "yes" : "no");
+    //D(bug("WebView::canShowMIMEType(%s): %s\n", type.utf8().data(), canShow ? "yes" : "no"));
     
     return canShow;
 }

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebChromeClient.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebChromeClient.cpp
@@ -70,12 +70,18 @@
 #include "gui.h"
 #include "utils.h"
 #include <proto/intuition.h>
-#include <clib/debug_protos.h>
 #include <proto/asl.h>
 #include "asl.h"
 #undef get
 #undef String
 #endif
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 #include <cstdio>
 
@@ -157,11 +163,11 @@ Page* WebChromeClient::createWindow(Frame*, const FrameLoadRequest& frameLoadReq
     
 	if (features.dialog)
 	{
-		kprintf("%s: features.dialog not implemented on MorphOS.\n", __PRETTY_FUNCTION__);
+		D(bug("%s: features.dialog not implemented on MorphOS.\n", __PRETTY_FUNCTION__));
 		return 0;
 	}
 
-	//kprintf("WebChromeClient::createWindow(url: <%s> framename: <%s> empty: %d)\n", frameLoadRequest.resourceRequest().url().string().utf8().data(), frameLoadRequest.frameName().utf8().data(),  frameLoadRequest.isEmpty());
+	//D(bug("WebChromeClient::createWindow(url: <%s> framename: <%s> empty: %d)\n", frameLoadRequest.resourceRequest().url().string().utf8().data(), frameLoadRequest.frameName().utf8().data(),  frameLoadRequest.isEmpty()));
 
 	ULONG frame = frameLoadRequest.isEmpty();
 	ULONG privatebrowsing = getv(m_webView->viewWindow()->browser, MA_OWBBrowser_PrivateBrowsing);
@@ -276,7 +282,7 @@ bool WebChromeClient::canRunBeforeUnloadConfirmPanel()
 
 bool WebChromeClient::runBeforeUnloadConfirmPanel(const String& message, Frame* frame)
 {
-    kprintf("runBeforeUnloadConfirmPanel: %s\n", message.utf8().data());
+    D(bug("runBeforeUnloadConfirmPanel: %s\n", message.utf8().data()));
     return false;
 }
 
@@ -392,28 +398,28 @@ void WebChromeClient::registerProtocolHandler(const String& scheme, const String
 void WebChromeClient::invalidateRootView(const IntRect& windowRect, bool immediate)
 {
     ASSERT(core(m_webView->topLevelFrame()));
-    //kprintf("WebChromeClient::invalidateRootView([%d, %d, %d, %d], immediate %d)\n", windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), immediate);
+    //D(bug("WebChromeClient::invalidateRootView([%d, %d, %d, %d], immediate %d)\n", windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), immediate));
     m_webView->repaint(windowRect, false /*contentChanged*/, immediate, false /*repaintContentOnly*/);
 }
 
 void WebChromeClient::invalidateContentsAndRootView(const IntRect& windowRect, bool immediate)
 {
     ASSERT(core(m_webView->topLevelFrame()));
-    //kprintf("WebChromeClient::invalidateContentsAndRootView([%d, %d, %d, %d], immediate %d)\n", windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), immediate);
+    //D(bug("WebChromeClient::invalidateContentsAndRootView([%d, %d, %d, %d], immediate %d)\n", windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), immediate));
     m_webView->repaint(windowRect, true /*contentChanged*/, immediate /*immediate*/, false /*repaintContentOnly*/);
 }
 
 void WebChromeClient::invalidateContentsForSlowScroll(const IntRect& windowRect, bool immediate)
 {
     ASSERT(core(m_webView->topLevelFrame()));
-    //kprintf("WebChromeClient::invalidateContentsForSlowScroll([%d, %d, %d, %d], immediate %d)\n", windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), immediate);
+    //D(bug("WebChromeClient::invalidateContentsForSlowScroll([%d, %d, %d, %d], immediate %d)\n", windowRect.x(), windowRect.y(), windowRect.width(), windowRect.height(), immediate));
     m_webView->repaint(windowRect, true /*contentChanged*/, immediate, true /*repaintContentOnly*/);
 }
 
 void WebChromeClient::scroll(const IntSize& delta, const IntRect& scrollViewRect, const IntRect& clipRect)
 {
     ASSERT(core(m_webView->topLevelFrame()));
-    //kprintf("WebChromeClient::scroll(delta[%d, %d], scrollViewRect[%d, %d, %d, %d], clipRect[%d, %d, %d, %d])\n", delta.width(), delta.height(), scrollViewRect.x(), scrollViewRect.y(), scrollViewRect.width(), scrollViewRect.height(), clipRect.x(), clipRect.y(), clipRect.width(), clipRect.height());
+    //D(bug("WebChromeClient::scroll(delta[%d, %d], scrollViewRect[%d, %d, %d, %d], clipRect[%d, %d, %d, %d])\n", delta.width(), delta.height(), scrollViewRect.x(), scrollViewRect.y(), scrollViewRect.width(), scrollViewRect.height(), clipRect.x(), clipRect.y(), clipRect.width(), clipRect.height()));
     m_webView->scrollBackingStore(core(m_webView->topLevelFrame())->view(), delta.width(), delta.height(), scrollViewRect, clipRect);
 }
 
@@ -524,7 +530,7 @@ PassOwnPtr<ColorChooser> WebChromeClient::createColorChooser(ColorChooserClient*
 PassRefPtr<DateTimeChooser> WebChromeClient::openDateTimeChooser(DateTimeChooserClient* chooserClient, const DateTimeChooserParameters& parameters)
 {
     /*
-    kprintf("WebChromeClient::openDateTimeChooser\n");
+    D(bug("WebChromeClient::openDateTimeChooser\n"));
 
     RefPtr<DateTimeChooserController> controller = adoptRef(new DateTimeChooserController(this, chooserClient, parameters));
     controller->openUI();
@@ -559,7 +565,7 @@ void WebChromeClient::runOpenPanel(Frame*, PassRefPtr<FileChooser> prpFileChoose
 			ULONG i;
 			for(i = 0; i < count; i++)
 			{
-				//kprintf("file = %s\n", files[i]);
+				//D(bug("file = %s\n", files[i]));
 				names.append(String(files[i]));
 			}
 
@@ -577,7 +583,7 @@ void WebChromeClient::runOpenPanel(Frame*, PassRefPtr<FileChooser> prpFileChoose
 
 		if(file)
 		{
-			//kprintf("file = %s\n", file);
+			//D(bug("file = %s\n", file));
 			chooser->chooseFile(String(file));
 			FreeVecTaskPooled(file);
 		}
@@ -674,13 +680,13 @@ void WebChromeClient::exitFullscreenForNode(WebCore::Node*)
 
 bool WebChromeClient::supportsFullScreenForElement(const WebCore::Element* element, bool)
 {
-	//kprintf("supportsFullScreenForElement %d %d\n", element && element->isMediaElement(), element && element->isMediaElement());
+	//D(bug("supportsFullScreenForElement %d %d\n", element && element->isMediaElement(), element && element->isMediaElement()));
     return element && element->isMediaElement();
 }
 
 void WebChromeClient::enterFullScreenForElement(WebCore::Element* element)
 {
-	//kprintf("enterFullScreenForElement\n");
+	//D(bug("enterFullScreenForElement\n"));
     element->document().webkitWillEnterFullScreenForElement(element);
     m_webView->enterFullScreenForElement(element);
     element->document().webkitDidEnterFullScreenForElement(element);
@@ -689,7 +695,7 @@ void WebChromeClient::enterFullScreenForElement(WebCore::Element* element)
 
 void WebChromeClient::exitFullScreenForElement(WebCore::Element*)
 {
-	//kprintf("exitFullScreenForElement\n");
+	//D(bug("exitFullScreenForElement\n"));
 
     // The element passed into this function is not reliable, i.e. it could
     // be null. In addition the parameter may be disappearing in the future.

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebChromeClient.h
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebChromeClient.h
@@ -32,8 +32,6 @@
 #include <ScrollTypes.h>
 #include <wtf/Forward.h>
 
-#include <clib/debug_protos.h>
-
 class WebDesktopNotificationsDelegate;
 class WebView;
 

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebContextMenuClient.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebContextMenuClient.cpp
@@ -48,7 +48,6 @@
 
 #if OS(MORPHOS)
 #include "gui.h"
-#include <clib/debug_protos.h>
 #undef String
 #endif
 

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebDesktopNotificationsDelegate.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebDesktopNotificationsDelegate.cpp
@@ -34,7 +34,11 @@
 #include "WebView.h"
 #include "CString.h"
 
-#include <clib/debug_protos.h>
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
 #define D(x)
 
 #if ENABLE(NOTIFICATIONS) || ENABLE(LEAGCY_NOTIFICATIONS)
@@ -53,30 +57,30 @@ bool WebDesktopNotificationsDelegate::show(Notification* object)
 
     object->setPendingActivity(object);
     
-    kprintf("show [%s]\n%s\n", object->title().latin1().data(), object->body().latin1().data());
+    D(bug("show [%s]\n%s\n", object->title().latin1().data(), object->body().latin1().data()));
 
     return true;
 }
 
 void WebDesktopNotificationsDelegate::cancel(Notification* object)
 {
-  D(kprintf("cancel\n"));
+  D(bug("cancel\n"));
 }
 
 void WebDesktopNotificationsDelegate::notificationObjectDestroyed(Notification*)
 {
-  D(kprintf("objectdestroyed\n"));
+  D(bug("objectdestroyed\n"));
 }
 
 void WebDesktopNotificationsDelegate:: notificationControllerDestroyed()
 {
-  D(kprintf("controllerdestroyed\n"));
+  D(bug("controllerdestroyed\n"));
 }
 
 #if ENABLE(LEGACY_NOTIFICATIONS)
 void WebDesktopNotificationsDelegate::requestPermission(WebCore::ScriptExecutionContext* context, PassRefPtr<VoidCallback> callback)
 {
-  D(kprintf("requestPermission (legacy)\n"));
+  D(bug("requestPermission (legacy)\n"));
 
 	NotificationClient::Permission permission = checkPermission(context);
 	if (permission != NotificationClient::PermissionNotAllowed) {
@@ -89,7 +93,7 @@ void WebDesktopNotificationsDelegate::requestPermission(WebCore::ScriptExecution
 
 void WebDesktopNotificationsDelegate::requestPermission(WebCore::ScriptExecutionContext* context, PassRefPtr<NotificationPermissionCallback> callback)
 {
-  D(kprintf("requestPermission\n"));
+  D(bug("requestPermission\n"));
 
     NotificationClient::Permission permission = checkPermission(context);
 	if (permission != NotificationClient::PermissionNotAllowed) {
@@ -101,12 +105,12 @@ void WebDesktopNotificationsDelegate::requestPermission(WebCore::ScriptExecution
 
 void WebDesktopNotificationsDelegate::cancelRequestsForPermission(ScriptExecutionContext*)
 {
-  D(kprintf("cancelRequestsForPermission\n"));
+  D(bug("cancelRequestsForPermission\n"));
 }
 
 NotificationClient::Permission WebDesktopNotificationsDelegate::checkPermission(WebCore::ScriptExecutionContext*)
 {
-  D(kprintf("checkPermission\n"));
+  D(bug("checkPermission\n"));
     /*
     int out = 0;
     if (hasNotificationDelegate())

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebDragClient.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebDragClient.cpp
@@ -75,9 +75,14 @@
 #include "CString.h"
 #include "gui.h"
 #include "utils.h"
-#include <clib/debug_protos.h>
-#define D(x)
 #endif
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 using namespace WebCore;
 
@@ -106,7 +111,7 @@ DragDestinationAction WebDragClient::actionMaskForDrag(DragData* dragData)
 void WebDragClient::willPerformDragDestinationAction(DragDestinationAction action, DragData* dragData)
 {
 #if OS(MORPHOS)
-	D(kprintf("willPerformDragDestinationAction action %d dragData %p\n", action, dragData));
+	D(bug("willPerformDragDestinationAction action %d dragData %p\n", action, dragData));
 #endif
     //Default delegate for willPerformDragDestinationAction has no side effects
     //so we just call the delegate, and don't worry about whether it's implemented
@@ -118,7 +123,7 @@ void WebDragClient::willPerformDragDestinationAction(DragDestinationAction actio
 DragSourceAction WebDragClient::dragSourceActionMaskForPoint(const IntPoint& windowPoint)
 {
 #if OS(MORPHOS)
-    D(kprintf("dragSourceActionMaskForPoint (%d %d)\n", windowPoint.x(), windowPoint.y()));
+    D(bug("dragSourceActionMaskForPoint (%d %d)\n", windowPoint.x(), windowPoint.y()));
     return DragSourceActionAny;
 #else
     return DragSourceActionAny;
@@ -128,7 +133,7 @@ DragSourceAction WebDragClient::dragSourceActionMaskForPoint(const IntPoint& win
 void WebDragClient::willPerformDragSourceAction(DragSourceAction action, const IntPoint& startPos, Clipboard*)
 {
 #if OS(MORPHOS)
-	D(kprintf("willPerformDragSourceAction %d (%d %d)\n", action, startPos.x(), startPos.y()));
+	D(bug("willPerformDragSourceAction %d (%d %d)\n", action, startPos.x(), startPos.y()));
 #endif
     // FIXME: Implement this!
     // See WebKit/win/WebCoreSupport/WebDragClient.cpp for how to implement it.
@@ -138,14 +143,14 @@ void WebDragClient::startDrag(DragImageRef image, const IntPoint& imageOrigin, c
 {
     RefPtr<Frame> frameProtector = frame;
 #if OS(MORPHOS)
-    D(kprintf("startDrag image %p islink %d imageOrigin (%d %d) dragPoint (%d %d) clipboard %p\n", image, isLink, imageOrigin.x(), imageOrigin.y(), dragPoint.x(), dragPoint.y(), clipboard));
+    D(bug("startDrag image %p islink %d imageOrigin (%d %d) dragPoint (%d %d) clipboard %p\n", image, isLink, imageOrigin.x(), imageOrigin.y(), dragPoint.x(), dragPoint.y(), clipboard));
 
     BalWidget *widget = m_webView->viewWindow();
 
     if(clipboard && widget)
     {
 	RefPtr<DataObjectMorphOS> dataObject = clipboard->pasteboard().dataObject();
-	D(kprintf("dataObject %p\n", dataObject.get()));
+	D(bug("dataObject %p\n", dataObject.get()));
 
 	if(!isLink)
 	{
@@ -174,10 +179,10 @@ void WebDragClient::startDrag(DragImageRef image, const IntPoint& imageOrigin, c
 
         DoMethod(widget->browser, MUIM_DoDrag, 0x80000000,0x80000000, 0);
 
-	D(kprintf("dragEnded\n"));
+	D(bug("dragEnded\n"));
 	core(m_webView)->dragController().dragEnded();
 
-	D(kprintf("after MUIM_DoDrag, resetting drag data\n"));
+	D(bug("after MUIM_DoDrag, resetting drag data\n"));
         set(widget->browser, MA_OWBBrowser_DragURL, "");
 	set(widget->browser, MA_OWBBrowser_DragImage, 0);
 	set(widget->browser, MA_OWBBrowser_DragData, 0);
@@ -189,7 +194,7 @@ void WebDragClient::startDrag(DragImageRef image, const IntPoint& imageOrigin, c
 DragImageRef WebDragClient::createDragImageForLink(KURL& url, const String& inLabel, Frame*)
 {
 #if OS(MORPHOS)
-	D(kprintf("createDragImageForLink %s %s\n", url.string().latin1().data(), inLabel.latin1().data()));
+	D(bug("createDragImageForLink %s %s\n", url.string().latin1().data(), inLabel.latin1().data()));
 
 	BalWidget *widget = m_webView->viewWindow();
 	if(widget)

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebEditorClient.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebEditorClient.cpp
@@ -56,10 +56,14 @@
 #ifndef __amigaos4__
 #include <proto/spellchecker.h>
 #endif
-#include <clib/debug_protos.h>
-
-#define D(x)
 #endif
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 using namespace WebCore;
 using namespace HTMLNames;
@@ -636,7 +640,7 @@ void WebEditorClient::learnWord(const String& word)
 	*/
 
 #if OS(MORPHOS)
-	D(kprintf("learnWord(%s)\n", word.utf8().data()));
+	D(bug("learnWord(%s)\n", word.utf8().data()));
 
 	String wordToLearn = word.lower();
 	STRPTR cword;
@@ -656,7 +660,7 @@ void WebEditorClient::learnWord(const String& word)
 
 		if(dictionary)
 		{
-			D(kprintf("Learning <%s>\n", cword));
+			D(bug("Learning <%s>\n", cword));
 
 			if(dictionary_can_learn())
 			{
@@ -682,7 +686,7 @@ void WebEditorClient::checkSpellingOfString(const UChar* text, int length, int* 
 	*/
 
 #if OS(MORPHOS)
-	D(kprintf("checkSpellingOfString(%s)\n", String(text, length).utf8().data()));
+	D(bug("checkSpellingOfString(%s)\n", String(text, length).utf8().data()));
 
 	int start = 0, len = 0, i = 0;
 	bool wordReached = false;
@@ -743,7 +747,7 @@ void WebEditorClient::checkSpellingOfString(const UChar* text, int length, int* 
 		if(dictionary)
 		{
 #ifndef __amigaos4__		
-			D(kprintf("Checking <%s>\n", cword));
+			D(bug("Checking <%s>\n", cword));
 
 			STRPTR *res = (STRPTR *) Suggest(dictionary, (STRPTR) cword, NULL);
 
@@ -807,7 +811,7 @@ void WebEditorClient::checkGrammarOfString(const UChar* text, int length, Vector
     }*/
 
 #if OS(MORPHOS)
-	//kprintf("checkGrammarOfString(%s)\n", String(text, length).utf8().data());
+	//D(bug("checkGrammarOfString(%s)\n", String(text, length).utf8().data()));
 	*badGrammarLocation = -1;
 	*badGrammarLength = 0;
 #endif
@@ -860,7 +864,7 @@ bool WebEditorClient::spellingUIIsShowing()
 void WebEditorClient::getGuessesForWord(const String& word, const String& context, Vector<String>& guesses)
 {
 #if OS(MORPHOS)
-	D(kprintf("getGuessesForWord(%s)\n", word.utf8().data()));
+	D(bug("getGuessesForWord(%s)\n", word.utf8().data()));
 
 	String isolatedWord;
 	UChar *text = (UChar *) word.characters();
@@ -916,7 +920,7 @@ void WebEditorClient::getGuessesForWord(const String& word, const String& contex
 		if(dictionary)
 		{
 #ifndef __amigaos4__		
-			D(kprintf("Checking <%s>\n", cword));
+			D(bug("Checking <%s>\n", cword));
 
 			STRPTR *res = (STRPTR *) Suggest(dictionary, (STRPTR) cword, NULL);
 
@@ -924,7 +928,7 @@ void WebEditorClient::getGuessesForWord(const String& word, const String& contex
 			{
 				while(*res)
 				{
-					D(kprintf("Suggested: <%s>\n", *res));
+					D(bug("Suggested: <%s>\n", *res));
 					STRPTR suggestedWord = local_to_utf8(*res);
 					if(suggestedWord && suggestedWord[0] != '\0')
 					{

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -94,10 +94,16 @@
 #include "utils.h"
 #include <proto/dos.h>
 #include <proto/intuition.h>
-#include <clib/debug_protos.h>
 #undef get
 #undef String
 #endif
+
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 #include <cstdio>
 
@@ -239,7 +245,7 @@ void WebFrameLoaderClient::dispatchDidReceiveResponse(DocumentLoader* loader, un
 {
 	//WebView* webView = m_webFrame->webView();
 
-	//kprintf("dispatchDidReceiveResponse:: loader %p webView %p\n", loader, webView);
+	//D(bug("dispatchDidReceiveResponse:: loader %p webView %p\n", loader, webView));
 	/*
     SharedPtr<WebResourceLoadDelegate> resourceLoadDelegate = webView->webResourceLoadDelegate();
     if (!resourceLoadDelegate)
@@ -255,7 +261,7 @@ void WebFrameLoaderClient::dispatchDidReceiveContentLength(DocumentLoader* loade
 {
 	//WebView* webView = m_webFrame->webView();
 
-	//kprintf("dispatchDidReceiveContentLength:: loader %p webView %p\n", loader, webView);
+	//D(bug("dispatchDidReceiveContentLength:: loader %p webView %p\n", loader, webView));
 	/*
     SharedPtr<WebResourceLoadDelegate> resourceLoadDelegate = webView->webResourceLoadDelegate();
     if (!resourceLoadDelegate)
@@ -269,7 +275,7 @@ void WebFrameLoaderClient::dispatchDidFinishLoading(DocumentLoader* loader, unsi
 {
 	//WebView* webView = m_webFrame->webView();
 
-	//kprintf("dispatchDidFinishLoading:: loader %p webView %p\n", loader, webView);
+	//D(bug("dispatchDidFinishLoading:: loader %p webView %p\n", loader, webView));
 	/*
     SharedPtr<WebResourceLoadDelegate> resourceLoadDelegate = webView->webResourceLoadDelegate();
     if (!resourceLoadDelegate)
@@ -283,10 +289,10 @@ void WebFrameLoaderClient::dispatchDidFailLoading(DocumentLoader* loader, unsign
 {
 	//WebView* webView = m_webFrame->webView();
 
-	//kprintf("dispatchDidFailLoading:: loader %p webView %p\n", loader, webView);
+	//D(bug("dispatchDidFailLoading:: loader %p webView %p\n", loader, webView));
 	/*
 	SharedPtr<WebResourceLoadDelegate> resourceLoadDelegate = webView->webResourceLoadDelegate();
-	kprintf("dispatchDidFailLoading:: resourceLoadDelegate %p\n", resourceLoadDelegate);
+	D(bug("dispatchDidFailLoading:: resourceLoadDelegate %p\n", resourceLoadDelegate));
     if (!resourceLoadDelegate)
         return;
 
@@ -896,14 +902,14 @@ bool WebFrameLoaderClient::canShowMIMEType(const String& type) const
 	  MIMETypeRegistry::isSupportedMediaMIMEType(ltype) ||
 	  PluginDatabase::installedPlugins()->isMIMETypeRegistered(ltype);
 
-	//kprintf("WebView::canShowMIMEType(%s): %s\n", ltype.utf8().data(), show ? "yes" : "no");
+	//D(bug("WebView::canShowMIMEType(%s): %s\n", ltype.utf8().data(), show ? "yes" : "no"));
 
 	return show;
 }
 
 bool WebFrameLoaderClient::canShowMIMETypeAsHTML(const WTF::String& MIMEType) const
 {
-	//kprintf("canShowMIMETypeAsHTML(%s)\n", MIMEType.latin1().data());
+	//D(bug("canShowMIMETypeAsHTML(%s)\n", MIMEType.latin1().data()));
 	return true;
 }
 

--- a/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebInspectorClient.cpp
+++ b/odyssey-r155188-1.23/Source/WebKit/OrigynWebBrowser/WebCoreSupport/WebInspectorClient.cpp
@@ -57,15 +57,19 @@
 #include "gui.h"
 #include "utils.h"
 #include <proto/intuition.h>
-#include <clib/debug_protos.h>
 #include <proto/asl.h>
 #include "asl.h"
-#define D(x)
 #undef get
 #undef set
 #undef String
 #endif
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 using namespace WebCore;
 using namespace std;
@@ -79,12 +83,12 @@ WebInspectorClient::WebInspectorClient(WebView *view)
 
 WebInspectorClient::~WebInspectorClient()
 {
-    D(kprintf("WebInspectorClient::~WebInspectorClient\n"));
+    D(bug("WebInspectorClient::~WebInspectorClient\n"));
 }
 
 void WebInspectorClient::inspectorDestroyed()
 {
-    D(kprintf("inspectorDestroyed\n"));
+    D(bug("inspectorDestroyed\n"));
     closeInspectorFrontend();
     delete this;
 }
@@ -134,7 +138,7 @@ void WebInspectorClient::bringFrontendToFront()
 
 void WebInspectorClient::releaseFrontend()
 {
-    D(kprintf("releaseFrontend\n"));
+    D(bug("releaseFrontend\n"));
     m_frontendPage = 0;
     m_frontendClient = 0;
 }
@@ -203,7 +207,7 @@ WebInspectorFrontendClient::WebInspectorFrontendClient(WebView* inspectedWebView
 
 WebInspectorFrontendClient::~WebInspectorFrontendClient()
 {
-	D(kprintf("WebInspectorFrontendClient::~WebInspectorFrontendClient\n"));
+	D(bug("WebInspectorFrontendClient::~WebInspectorFrontendClient\n"));
 	destroyInspectorView(true); 
 }
 
@@ -233,7 +237,7 @@ void WebInspectorFrontendClient::bringToFront()
 
 void WebInspectorFrontendClient::closeWindow()
 {
-	D(kprintf("closeWindow\n"));
+	D(bug("closeWindow\n"));
 	destroyInspectorView(true);
 }
 
@@ -274,13 +278,13 @@ void WebInspectorFrontendClient::setToolbarHeight(unsigned)
 
 void WebInspectorFrontendClient::inspectedURLChanged(const String& newURL)
 {
-    D(kprintf("inspectedURLChanged <%s>\n", newURL.latin1().data()));
+    D(bug("inspectedURLChanged <%s>\n", newURL.latin1().data()));
     notImplemented();
 }
 
 void WebInspectorFrontendClient::destroyInspectorView(bool notifyInspectorController)
 {
-    D(kprintf("this %p destroyInspectorView(%d)\n", this, notifyInspectorController));
+    D(bug("this %p destroyInspectorView(%d)\n", this, notifyInspectorController));
 
     m_inspectorClient->releaseFrontend();
 
@@ -291,7 +295,7 @@ void WebInspectorFrontendClient::destroyInspectorView(bool notifyInspectorContro
 
 	if (notifyInspectorController)
 	{
-		D(kprintf("disconnectFrontend\n"));
+		D(bug("disconnectFrontend\n"));
 		if(m_inspectedWebView)
 		{
 			core(m_inspectedWebView)->inspectorController()->disconnectFrontend();

--- a/odyssey-r155188-1.23/Tools/OWBLauncher/CMakeLists.txt
+++ b/odyssey-r155188-1.23/Tools/OWBLauncher/CMakeLists.txt
@@ -33,7 +33,7 @@ endif(USE_GRAPHICS_MORPHOS)
 
 target_link_libraries(Odyssey
     webkit-owb
-    -static -athread=single -L../../lib -Llib webkit-owb webcore jsc wtf -lcairo -lpixman-1 -lfontconfig -lfreetype -lcurl -lrtmp -ljpeg -lpng -lwebp -lsqlite3 -lxslt -lavdevice2 -lavformat2 -lavcodec2 -lavutil2 -lswscale2 -lswresample2 -lxml2 -lexpat -lbz2 -lssl -lcrypto -licui18n -licuuc -licudata -lpthread -ldebug -laos4deps -lauto -lz
+    -static -athread=single -L../../lib -Llib webkit-owb webcore jsc wtf -lcairo -lpixman-1 -lfontconfig -lfreetype -lcurl -lrtmp -ljpeg -lpng -lwebp -lsqlite3 -lxslt -lavdevice2 -lavformat2 -lavcodec2 -lavutil2 -lswscale2 -lswresample2 -lxml2 -lexpat -lbz2 -lssl -lcrypto -licui18n -licuuc -licudata -lpthread -laos4deps -lauto -lz
 #    ${EXTERNAL_DEPS_LIBRARIES}
 )
 

--- a/odyssey-r155188-1.23/Tools/OWBLauncher/MorphOS/main.cpp
+++ b/odyssey-r155188-1.23/Tools/OWBLauncher/MorphOS/main.cpp
@@ -52,14 +52,10 @@
 #include <locale.h>
 #include <setjmp.h>
 
-#include <clib/debug_protos.h>
-
 #include "gui.h"
 #include "../../../Source/WebKit/OrigynWebBrowser/Api/MorphOS/alocale.h"
 
 #undef accept
-
-#define D(x)
 
 #include <proto/intuition.h>
 #include <proto/codesets.h>
@@ -70,6 +66,12 @@
 #include <reaction/reaction_macros.h>
 #include <diskfont/diskfonttag.h>
 
+/* Debug output to serial handled via D(bug("....."));
+*  See Base/debug.h for details.
+*  D(x)    - to disable debug
+*  D(x) x  - to enable debug
+*/
+#define D(x)
 
 void close_dictionary();
 void destroy_application(void);
@@ -92,7 +94,7 @@ extern "C"
 {
 	int raise(int sig)
 	{
-		kprintf("raise(%d) was called, dumping stackframe...\n", sig);
+		D(bug("raise(%d) was called, dumping stackframe...\n", sig));
 		#ifndef __amigaos4__
 		DumpTaskState(FindTask(NULL));
 		#endif
@@ -102,7 +104,7 @@ extern "C"
 	/*
 	void abort(void)
 	{
-		kprintf("abort was called, dumping stackframe...\n");
+		D(bug("abort was called, dumping stackframe...\n"));
 
 		DumpTaskState(FindTask(NULL));
 
@@ -505,7 +507,7 @@ void main_loop(void)
 		/*
 		if(signals & dosnotifysig )
 		{
-			//kprintf("DosNotify Trig\n");
+			//D(bug("DosNotify Trig\n"));
 			//DoMethod(getv(app, MA_OWBApp_BookmarkGroup), MM_Bookmarkgroup_DosNotify);
 		}
 		*/


### PR DESCRIPTION
…can be used. Thus we use DebugPrintF() on OS4 everywhere instead of kprintf() and get rid of clib2's libdebug.a. See Base/debug.h for more details.